### PR TITLE
Remove 'firmware_type' from endpoint instance show info.

### DIFF
--- a/coriolisclient/cli/endpoint_instances.py
+++ b/coriolisclient/cli/endpoint_instances.py
@@ -54,8 +54,7 @@ class InstancesDetailFormatter(formatter.EntityFormatter):
             "Memory MB",
             "Cores",
             "OS Type",
-            "Devices",
-            "Firmware type"
+            "Devices"
         ]
 
     def _get_formatted_data(self, obj):
@@ -67,8 +66,7 @@ class InstancesDetailFormatter(formatter.EntityFormatter):
             obj.memory_mb,
             obj.num_cpu,
             obj.os_type,
-            obj.devices,
-            obj.firmware_type
+            obj.devices
         ]
 
         return data


### PR DESCRIPTION
The 'firmware_type' attribute is not mandatory in the response for an `endpoint instance show` request, and should ideally not be shown.