### PR TITLE
Add support for specifying 'storage_mappings'.

### DIFF
--- a/coriolisclient/cli/utils.py
+++ b/coriolisclient/cli/utils.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2018 Cloudbase Solutions Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def add_storage_mappings_arguments_to_parser(parser):
+    """ Given an `argparse.ArgumentParser` instance, add the arguments required
+    for the 'storage_mappings' field for both Migrations and Replicas:
+        * '--default-storage-backend' will be under 'default_storage_backend'
+        * '--disk-storage-mapping's will be under 'disk_storage_mappings'
+        * '--storage-backend-mapping's will be under 'storage_backend_mappings'
+    """
+    parser.add_argument(
+        "--default-storage-backend",
+        dest='default_storage_backend',
+        help="Name of a storage backend on the destination platform to "
+             "default to using.")
+
+    # NOTE: arparse will just call whatever 'type=' was supplied on a value
+    # so we can pass in a single-arg function to have it modify the value:
+    def _split_disk_arg(arg):
+        disk_id, dest = arg.split('=')
+        return {
+            "disk_id": disk_id.strip('\'"'),
+            "destination": dest.strip('\'"')}
+    parser.add_argument(
+        "--disk-storage-mapping", action='append', type=_split_disk_arg,
+        dest='disk_storage_mappings',
+        help="Mappings between IDs of the source VM's disks and the names of "
+             "storage backends on the destination platform as seen by running "
+             "`coriolis endpoint storage list $DEST_ENDPOINT_ID`. "
+             "Values should be fomatted with '=' (ex: \"id#1=lvm)\"."
+             "Can be specified multiple times for multiple disks.")
+
+    def _split_backend_arg(arg):
+        src, dest = arg.split('=')
+        return {
+            "source": src.strip('\'"'),
+            "destination": dest.strip('\'"')}
+    parser.add_argument(
+        "--storage-backend-mapping", action='append', type=_split_backend_arg,
+        dest='storage_backend_mappings',
+        help="Mappings between names of source and destination storage "
+        "backends  as seen by running `coriolis endpoint storage "
+        "list $DEST_ENDPOINT_ID`. Values should be fomatted with '=' "
+        "(ex: \"id#1=lvm)\". Can be specified multiple times for "
+        "multiple backends.")
+
+
+def get_storage_mappings_dict_from_args(args):
+    storage_mappings = {}
+
+    if args.default_storage_backend:
+        storage_mappings["default"] = args.default_storage_backend
+
+    if args.disk_storage_mappings:
+        storage_mappings["disk_mappings"] = args.disk_storage_mappings
+
+    if args.storage_backend_mappings:
+        storage_mappings["backend_mappings"] = args.storage_backend_mappings
+
+    return storage_mappings
+
+
+def format_mapping(mapping):
+    """ Given a str-str mapping, formats it as a string. """
+    return ", ".join(
+        ["'%s'='%s'" % (k, v) for k, v in mapping.items()])
+
+
+def parse_storage_mappings(storage_mappings):
+    """ Given the 'storage_mappings' API field, returns a tuple with the
+    'default' option, the 'backend_mappings' and 'disk_mappings'.
+    """
+    # NOTE: the 'storage_mappings' property is Nullable:
+    if storage_mappings is None:
+        return None, {}, {}
+
+    backend_mappings = {
+        mapping['source']: mapping['destination']
+        for mapping in storage_mappings.get("backend_mappings", [])}
+    disk_mappings = {
+        mapping['disk_id']: mapping['destination']
+        for mapping in storage_mappings.get("disk_mappings", [])}
+
+    return (
+        storage_mappings.get("default"), backend_mappings, disk_mappings)

--- a/coriolisclient/v1/migrations.py
+++ b/coriolisclient/v1/migrations.py
@@ -48,16 +48,20 @@ class MigrationManager(base.BaseManager):
 
     def create(self, origin_endpoint_id, destination_endpoint_id,
                destination_environment, instances, network_map=None,
-               skip_os_morphing=False):
+               storage_mappings=None, skip_os_morphing=False):
         if not network_map:
             network_map = destination_environment.get('network_map', {})
+        if not storage_mappings:
+            storage_mappings = destination_environment.get(
+                'storage_mappings', {})
         data = {"migration": {
             "origin_endpoint_id": origin_endpoint_id,
             "destination_endpoint_id": destination_endpoint_id,
             "destination_environment": destination_environment,
             "instances": instances,
             "skip_os_morphing": skip_os_morphing,
-            "network_map": network_map}
+            "network_map": network_map,
+            "storage_mappings": storage_mappings}
         }
         return self._post('/migrations', data, 'migration')
 

--- a/coriolisclient/v1/replicas.py
+++ b/coriolisclient/v1/replicas.py
@@ -48,16 +48,21 @@ class ReplicaManager(base.BaseManager):
         return self._get('/replicas/%s' % base.getid(replica), 'replica')
 
     def create(self, origin_endpoint_id, destination_endpoint_id,
-               destination_environment, instances, network_map=None):
+               destination_environment, instances, network_map=None,
+               storage_mappings=None):
         if not network_map:
             network_map = destination_environment.get('network_map', {})
+        if not storage_mappings:
+            storage_mappings = destination_environment.get(
+                'storage_mappings', {})
         data = {
             "replica": {
                 "origin_endpoint_id": origin_endpoint_id,
                 "destination_endpoint_id": destination_endpoint_id,
                 "destination_environment": destination_environment,
                 "instances": instances,
-                "network_map": network_map
+                "network_map": network_map,
+                "storage_mappings": storage_mappings
             }
         }
         return self._post('/replicas', data, 'replica')


### PR DESCRIPTION
Add support for both defining and showing the 'storage_mappings' fields
of Migrations/Replicas.

The user can specify the 'storage_mappings' values using the following
arguments:
    * '--default-storage-backend' for storage_mappings['default']
    * '--disk-storage-mapping's for storage_mappings['disk_mappings']
    * '--storage-backend-mapping's for storage_mappings['backend_mappings']