### PR TITLE
Remove base64 encoding of instance name to from CLI layer.

### DIFF
--- a/coriolisclient/cli/endpoint_instances.py
+++ b/coriolisclient/cli/endpoint_instances.py
@@ -17,8 +17,6 @@
 Command-line interface sub-commands related to endpoints.
 """
 
-import base64
-from builtins import bytes
 import json
 
 from cliff import lister
@@ -126,6 +124,5 @@ class ShowEndpointInstance(show.ShowOne):
         endpoint_id = endpoints.get_endpoint_id_for_name(args.endpoint)
         ei = self.app.client_manager.coriolis.endpoint_instances
         obj = ei.get(
-            endpoint_id,
-            base64.b64encode(bytes(args.instance, 'utf-8')).decode())
+            endpoint_id, args.instance)
         return InstancesDetailFormatter().get_formatted_entity(obj)

--- a/coriolisclient/v1/endpoint_instances.py
+++ b/coriolisclient/v1/endpoint_instances.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import base64
+from builtins import bytes
 
 from six.moves.urllib import parse as urlparse
 
@@ -49,7 +50,8 @@ class EndpointInstanceManager(base.BaseManager):
         return self._list(url, 'instances')
 
     def get(self, endpoint, instance_id):
-        encoded_instance = base64.b64encode(instance_id.encode()).decode()
+        encoded_instance = base64.b64encode(
+            bytes(instance_id, 'utf-8')).decode()
         url = '/endpoints/%s/instances/%s' % (
             base.getid(endpoint), encoded_instance)
         return self._get(url, 'instance')


### PR DESCRIPTION
Considering the fact that the instance's name/ID needing to be
encoded in base64 is a quirk of the API, the act of encoding it
should be handled directly in coriolisclient.v1.endpoint_instances