### PR TITLE
Add unit tests for `coriolisclient.cli.diagnostics` module

### DIFF
--- a/coriolisclient/tests/cli/test_diagnostics.py
+++ b/coriolisclient/tests/cli/test_diagnostics.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Cloudbase Solutions Srl
 # All Rights Reserved.
 
+from cliff import lister
 from unittest import mock
 
 from coriolisclient.cli import diagnostics
@@ -12,18 +13,76 @@ class DiagnosticsFormatterTestCase(test_base.CoriolisBaseTestCase):
 
     def setUp(self):
         super(DiagnosticsFormatterTestCase, self).setUp()
-        self.diagnostics = diagnostics.DiagnosticsFormatter()
+        self.diag = diagnostics.DiagnosticsFormatter()
 
     def test_get_sorted_list(self):
         obj1 = mock.Mock()
         obj2 = mock.Mock()
+        obj3 = mock.Mock()
         obj1.application = "app1"
         obj2.application = "app2"
-        obj_list = [obj2, obj1]
+        obj3.application = "app3"
+        obj_list = [obj2, obj1, obj3]
 
-        result = self.diagnostics._get_sorted_list(obj_list)
+        result = self.diag._get_sorted_list(obj_list)
 
         self.assertEqual(
-            [obj1, obj2],
+            [obj1, obj2, obj3],
             result
         )
+
+    def test_get_formatted_data(self):
+        obj = mock.Mock()
+        obj.application = mock.sentinel.application
+        obj.hostname = mock.sentinel.hostname
+        obj.ip_addresses = mock.sentinel.ip_addresses
+        obj.packages = mock.sentinel.packages
+        obj.os_info = mock.sentinel.os_info
+
+        result = self.diag._get_formatted_data(obj)
+
+        self.assertEqual(
+            (
+                mock.sentinel.application,
+                mock.sentinel.hostname,
+                mock.sentinel.ip_addresses,
+                mock.sentinel.packages,
+                mock.sentinel.os_info
+            ),
+            result
+        )
+
+
+class GetCoriolisDiagnosticsTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Get Coriolis Diagnostics."""
+
+    @mock.patch.object(lister.Lister, '__init__')
+    def setUp(self, mock__init__):
+        mock__init__.return_value = None
+        super(GetCoriolisDiagnosticsTestCase, self).setUp()
+        self.diag = diagnostics.GetCoriolisDiagnostics()
+
+    @mock.patch.object(diagnostics.GetCoriolisDiagnostics, 'get_parser')
+    def test_get_parser(self, mock_get_parser):
+        result = self.diag.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(diagnostics.DiagnosticsFormatter, 'list_objects')
+    def test_take_action(self, mock_list_objects):
+        mock_app = mock.Mock()
+        self.diag.app = mock_app
+        result = self.diag.take_action(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_list_objects.return_value,
+            result
+        )
+        (mock_app.client_manager.coriolis.diagnostics.get.
+         assert_called_once)()
+        mock_list_objects.assert_called_once_with(
+            mock_app.client_manager.coriolis.diagnostics.get.return_value)

--- a/coriolisclient/v1/logging.py
+++ b/coriolisclient/v1/logging.py
@@ -127,7 +127,8 @@ class LoggingClient(object):
             _ = datetime.datetime.fromtimestamp(int(period))
             return int(period)
         except (OverflowError, OSError):
-            LOG.warning("Failed to initialize timestamp from period value: %d", period)
+            LOG.warning("Failed to initialize timestamp from period value: %d",
+                        period)
         except ValueError:
             LOG.warning("Invalid value type for period: %s", period)
         units = {


### PR DESCRIPTION
This PR adds unit tests for `coriolisclient.cli.diagnostics` module