### PR TITLE
Add unit tests for `coriolisclient.cli.endpoint*` modules

### DIFF
--- a/coriolisclient/cli/endpoints.py
+++ b/coriolisclient/cli/endpoints.py
@@ -43,7 +43,7 @@ def add_connection_info_args_to_parser(parser):
     return parser
 
 
-def get_connnection_info_from_args(args, raise_if_none=True):
+def get_connection_info_from_args(args, raise_if_none=True):
     """ Returns a dict with the connection info from the arguments. """
     conn_info = None
     raw_conn_info = None
@@ -148,7 +148,7 @@ class CreateEndpoint(show.ShowOne):
                 "Please specify either --connection or "
                 "--connection-secret, but not both")
 
-        conn_info = get_connnection_info_from_args(args)
+        conn_info = get_connection_info_from_args(args)
         endpoint = self.app.client_manager.coriolis.endpoints.create(
             args.name,
             args.provider,
@@ -191,7 +191,7 @@ class UpdateEndpoint(show.ShowOne):
                 "Please specify either --connection or "
                 "--connection-secret, but not both")
 
-        conn_info = get_connnection_info_from_args(args, raise_if_none=False)
+        conn_info = get_connection_info_from_args(args, raise_if_none=False)
         updated_values = {}
         if args.name is not None:
             updated_values["name"] = args.name

--- a/coriolisclient/tests/cli/test_diagnostics.py
+++ b/coriolisclient/tests/cli/test_diagnostics.py
@@ -62,8 +62,9 @@ class GetCoriolisDiagnosticsTestCase(test_base.CoriolisBaseTestCase):
         super(GetCoriolisDiagnosticsTestCase, self).setUp()
         self.diag = diagnostics.GetCoriolisDiagnostics()
 
-    @mock.patch.object(diagnostics.GetCoriolisDiagnostics, 'get_parser')
+    @mock.patch.object(lister.Lister, 'get_parser')
     def test_get_parser(self, mock_get_parser):
+        mock_get_parser.return_value = None
         result = self.diag.get_parser(mock.sentinel.prog_name)
 
         self.assertEqual(

--- a/coriolisclient/tests/cli/test_endpoint_destination_minion_pool_options.py
+++ b/coriolisclient/tests/cli/test_endpoint_destination_minion_pool_options.py
@@ -1,0 +1,122 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from cliff import lister
+from unittest import mock
+
+from coriolisclient.cli import endpoint_destination_minion_pool_options
+from coriolisclient.cli import utils as cli_utils
+from coriolisclient.tests import test_base
+
+
+class EndpointDestinationMinionPoolOptionsFormatterTestCase(
+        test_base.CoriolisBaseTestCase):
+    """
+    Test suite for the Coriolis Client Endpoint Destination Minion Pool
+    Options Formatter.
+    """
+
+    def setUp(self):
+        super(EndpointDestinationMinionPoolOptionsFormatterTestCase, self
+              ).setUp()
+        self.endpoint = (endpoint_destination_minion_pool_options.
+                         EndpointDestinationMinionPoolOptionsFormatter)()
+
+    def test_get_sorted_list(self):
+        obj1 = mock.Mock()
+        obj2 = mock.Mock()
+        obj3 = mock.Mock()
+        obj1.name = "app1"
+        obj2.name = "app2"
+        obj3.name = "app3"
+        obj_list = [obj2, obj1, obj3]
+
+        result = self.endpoint._get_sorted_list(obj_list)
+
+        self.assertEqual(
+            [obj1, obj2, obj3],
+            result
+        )
+
+    @mock.patch.object(cli_utils, 'format_json_for_object_property')
+    def test_get_formatted_data(self, mock_format_json_for_object_property):
+        obj = mock.Mock()
+        obj.name = mock.sentinel.name
+        obj.to_dict = mock.Mock(
+            return_value={"config_default": mock.sentinel.config_default}
+        )
+
+        result = self.endpoint._get_formatted_data(obj)
+
+        self.assertEqual(
+            (
+                mock.sentinel.name,
+                mock_format_json_for_object_property.return_value,
+                mock.sentinel.config_default
+            ),
+            result
+        )
+
+
+class ListEndpointDestinationMinionPoolOptionsTestCase(
+        test_base.CoriolisBaseTestCase):
+    """
+    Test suite for the Coriolis Client List Endpoint Destination Minion Pool
+    Options.
+    """
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ListEndpointDestinationMinionPoolOptionsTestCase, self).setUp()
+        self.endpoint = (endpoint_destination_minion_pool_options.
+                         ListEndpointDestinationMinionPoolOptions)(
+                             self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(cli_utils, 'add_args_for_json_option_to_parser')
+    @mock.patch.object(lister.Lister, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+        mock_add_args_for_json_option_to_parser
+    ):
+        result = self.endpoint.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+        mock_add_args_for_json_option_to_parser.assert_called_once_with(
+            mock_get_parser.return_value, 'environment')
+
+    @mock.patch.object(endpoint_destination_minion_pool_options.
+                       EndpointDestinationMinionPoolOptionsFormatter,
+                       'list_objects')
+    @mock.patch.object(cli_utils, 'get_option_value_from_args')
+    def test_take_action(
+        self,
+        mock_get_option_value_from_args,
+        mock_list_objects
+    ):
+        args = mock.Mock()
+        args.options = mock.sentinel.options
+        mock_endpoints = mock.Mock()
+        mock_empdo = mock.Mock()
+        self.mock_app.client_manager.coriolis.endpoints = mock_endpoints
+        mock_empdo = (self.mock_app.client_manager.coriolis.
+                      endpoint_destination_minion_pool_options)
+
+        result = self.endpoint.take_action(args)
+
+        self.assertEqual(
+            mock_list_objects.return_value,
+            result
+        )
+        mock_get_option_value_from_args.assert_called_once_with(
+            args, 'environment', error_on_no_value=False)
+        mock_empdo.list.assert_called_once_with(
+            mock_endpoints.get_endpoint_id_for_name(args.endpoint),
+            environment=mock_get_option_value_from_args.return_value,
+            option_names=mock.sentinel.options
+        )
+        mock_list_objects.assert_called_once_with(mock_empdo.list.return_value)

--- a/coriolisclient/tests/cli/test_endpoint_destination_options.py
+++ b/coriolisclient/tests/cli/test_endpoint_destination_options.py
@@ -1,0 +1,120 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from cliff import lister
+from unittest import mock
+
+from coriolisclient.cli import endpoint_destination_options
+from coriolisclient.cli import utils as cli_utils
+from coriolisclient.tests import test_base
+
+
+class EndpointDestinationOptionFormatterTestCase(
+        test_base.CoriolisBaseTestCase):
+    """
+    Test suite for the Coriolis Client Endpoint Destination Options Formatter.
+    """
+
+    def setUp(self):
+        super(EndpointDestinationOptionFormatterTestCase, self
+              ).setUp()
+        self.endpoint = (endpoint_destination_options.
+                         EndpointDestinationOptionFormatter)()
+
+    def test_get_sorted_list(self):
+        obj1 = mock.Mock()
+        obj2 = mock.Mock()
+        obj3 = mock.Mock()
+        obj1.name = "app1"
+        obj2.name = "app2"
+        obj3.name = "app3"
+        obj_list = [obj2, obj1, obj3]
+
+        result = self.endpoint._get_sorted_list(obj_list)
+
+        self.assertEqual(
+            [obj1, obj2, obj3],
+            result
+        )
+
+    @mock.patch.object(cli_utils, 'format_json_for_object_property')
+    def test_get_formatted_data(self, mock_format_json_for_object_property):
+        obj = mock.Mock()
+        obj.name = mock.sentinel.name
+        obj.to_dict = mock.Mock(
+            return_value={"config_default": mock.sentinel.config_default}
+        )
+
+        result = self.endpoint._get_formatted_data(obj)
+
+        self.assertEqual(
+            (
+                mock.sentinel.name,
+                mock_format_json_for_object_property.return_value,
+                mock.sentinel.config_default
+            ),
+            result
+        )
+
+
+class ListEndpointDestinationOptionsTestCase(
+        test_base.CoriolisBaseTestCase):
+    """
+    Test suite for the Coriolis Client List Endpoint Destination Options.
+    """
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ListEndpointDestinationOptionsTestCase, self).setUp()
+        self.endpoint = (
+            endpoint_destination_options.ListEndpointDestinationOptions)(
+                self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(cli_utils, 'add_args_for_json_option_to_parser')
+    @mock.patch.object(lister.Lister, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+        mock_add_args_for_json_option_to_parser
+    ):
+        result = self.endpoint.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+        mock_add_args_for_json_option_to_parser.assert_called_once_with(
+            mock_get_parser.return_value, 'environment')
+
+    @mock.patch.object(endpoint_destination_options.
+                       EndpointDestinationOptionFormatter,
+                       'list_objects')
+    @mock.patch.object(cli_utils, 'get_option_value_from_args')
+    def test_take_action(
+        self,
+        mock_get_option_value_from_args,
+        mock_list_objects
+    ):
+        args = mock.Mock()
+        args.options = mock.sentinel.options
+        mock_endpoints = mock.Mock()
+        mock_edo = mock.Mock()
+        self.mock_app.client_manager.coriolis.endpoints = mock_endpoints
+        mock_edo = (self.mock_app.client_manager.coriolis.
+                    endpoint_destination_options)
+
+        result = self.endpoint.take_action(args)
+
+        self.assertEqual(
+            mock_list_objects.return_value,
+            result
+        )
+        mock_get_option_value_from_args.assert_called_once_with(
+            args, 'environment', error_on_no_value=False)
+        mock_edo.list.assert_called_once_with(
+            mock_endpoints.get_endpoint_id_for_name(args.endpoint),
+            environment=mock_get_option_value_from_args.return_value,
+            option_names=mock.sentinel.options
+        )
+        mock_list_objects.assert_called_once_with(mock_edo.list.return_value)

--- a/coriolisclient/tests/cli/test_endpoint_instances.py
+++ b/coriolisclient/tests/cli/test_endpoint_instances.py
@@ -1,0 +1,216 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from cliff import lister
+from cliff import show
+from unittest import mock
+
+from coriolisclient.cli import endpoint_instances
+from coriolisclient.cli import utils as cli_utils
+from coriolisclient.tests import test_base
+
+
+class EndpointInstanceFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Endpoint Instance Formatter."""
+
+    def setUp(self):
+        super(EndpointInstanceFormatterTestCase, self).setUp()
+        self.endpoint = endpoint_instances.EndpointInstanceFormatter()
+
+    def test_get_formatted_data(self):
+        obj = mock.Mock()
+        obj.id = mock.sentinel.id
+        obj.flavor_name = mock.sentinel.flavor_name
+        obj.memory_mb = mock.sentinel.memory_mb
+        obj.num_cpu = mock.sentinel.num_cpu
+        obj.os_type = mock.sentinel.os_type
+        obj.to_dict = mock.Mock(
+            return_value={"instance_name": mock.sentinel.instance_name}
+        )
+
+        result = self.endpoint._get_formatted_data(obj)
+
+        self.assertEqual(
+            (
+                mock.sentinel.id,
+                mock.sentinel.instance_name,
+                mock.sentinel.flavor_name,
+                mock.sentinel.memory_mb,
+                mock.sentinel.num_cpu,
+                mock.sentinel.os_type
+            ),
+            result
+        )
+
+
+class InstancesDetailFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Instances Detail Formatter."""
+
+    def setUp(self):
+        super(InstancesDetailFormatterTestCase, self).setUp()
+        self.endpoint = endpoint_instances.InstancesDetailFormatter()
+
+    def test_get_formatted_data(self):
+        obj = mock.Mock()
+        obj.id = mock.sentinel.id
+        obj.name = mock.sentinel.name
+        obj.flavor_name = mock.sentinel.flavor_name
+        obj.memory_mb = mock.sentinel.memory_mb
+        obj.num_cpu = mock.sentinel.num_cpu
+        obj.os_type = mock.sentinel.os_type
+        obj.to_dict = mock.Mock(
+            return_value={"instance_name": mock.sentinel.instance_name,
+                          "firmware_type": mock.sentinel.firmware_type}
+        )
+        devices = {
+            "controllers": ["controller1", "controller2"],
+            "disks": ["disk1", "disk2"],
+            "nics": ["nic1", "nic2"],
+            "cdroms": ["cdrom1", "cdrom2"],
+            "floppies": ["floppy1", "floppy2"],
+            "serial_ports": ["serial_port1", "serial_port2"]
+        }
+        obj.devices = devices
+
+        result = self.endpoint._get_formatted_data(obj)
+
+        self.assertEqual(
+            [
+                mock.sentinel.id,
+                mock.sentinel.name,
+                mock.sentinel.instance_name,
+                mock.sentinel.flavor_name,
+                mock.sentinel.memory_mb,
+                mock.sentinel.num_cpu,
+                mock.sentinel.os_type,
+                mock.sentinel.firmware_type,
+                '[\n  "controller1",\n  "controller2"\n]',
+                '[\n  "disk1",\n  "disk2"\n]',
+                '[\n  "nic1",\n  "nic2"\n]',
+                '[\n  "cdrom1",\n  "cdrom2"\n]',
+                '[\n  "floppy1",\n  "floppy2"\n]',
+                '[\n  "serial_port1",\n  "serial_port2"\n]'
+            ],
+            result
+        )
+
+
+class ListEndpointInstanceTestCase(
+        test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client List Endpoint Instance."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ListEndpointInstanceTestCase, self).setUp()
+        self.endpoint = endpoint_instances.ListEndpointInstance(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(cli_utils, 'add_args_for_json_option_to_parser')
+    @mock.patch.object(lister.Lister, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+        mock_add_args_for_json_option_to_parser
+    ):
+        result = self.endpoint.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+        mock_add_args_for_json_option_to_parser.assert_called_once_with(
+            mock_get_parser.return_value, 'environment')
+
+    @mock.patch.object(endpoint_instances.EndpointInstanceFormatter,
+                       'list_objects')
+    @mock.patch.object(cli_utils, 'get_option_value_from_args')
+    def test_take_action(
+        self,
+        mock_get_option_value_from_args,
+        mock_list_objects
+    ):
+        args = mock.Mock()
+        args.marker = mock.sentinel.marker
+        args.limit = mock.sentinel.limit
+        args.name = mock.sentinel.name
+        mock_endpoints = mock.Mock()
+        mock_ei = mock.Mock()
+        self.mock_app.client_manager.coriolis.endpoints = mock_endpoints
+        mock_ei = self.mock_app.client_manager.coriolis.endpoint_instances
+
+        result = self.endpoint.take_action(args)
+
+        self.assertEqual(
+            mock_list_objects.return_value,
+            result
+        )
+        mock_get_option_value_from_args.assert_called_once_with(
+            args, 'environment', error_on_no_value=False)
+        mock_ei.list.assert_called_once_with(
+            mock_endpoints.get_endpoint_id_for_name(args.endpoint),
+            mock_get_option_value_from_args.return_value,
+            mock.sentinel.marker,
+            mock.sentinel.limit,
+            mock.sentinel.name
+        )
+        mock_list_objects.assert_called_once_with(mock_ei.list.return_value)
+
+
+class ShowEndpointInstanceTestCase(
+        test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client List Show Endpoint Instance"""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ShowEndpointInstanceTestCase, self).setUp()
+        self.endpoint = endpoint_instances.ShowEndpointInstance(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(cli_utils, 'add_args_for_json_option_to_parser')
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+        mock_add_args_for_json_option_to_parser
+    ):
+        result = self.endpoint.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+        mock_add_args_for_json_option_to_parser.assert_called_once_with(
+            mock_get_parser.return_value, 'environment')
+
+    @mock.patch.object(endpoint_instances.InstancesDetailFormatter,
+                       'get_formatted_entity')
+    @mock.patch.object(cli_utils, 'get_option_value_from_args')
+    def test_take_action(
+        self,
+        mock_get_option_value_from_args,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.instance = mock.sentinel.instance
+        mock_endpoints = mock.Mock()
+        mock_ei = mock.Mock()
+        self.mock_app.client_manager.coriolis.endpoints = mock_endpoints
+        mock_ei = self.mock_app.client_manager.coriolis.endpoint_instances
+
+        result = self.endpoint.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_get_option_value_from_args.assert_called_once_with(
+            args, 'environment', error_on_no_value=False)
+        mock_ei.get.assert_called_once_with(
+            mock_endpoints.get_endpoint_id_for_name(args.endpoint),
+            mock.sentinel.instance,
+            mock_get_option_value_from_args.return_value,
+        )
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_ei.get.return_value)

--- a/coriolisclient/tests/cli/test_endpoint_networks.py
+++ b/coriolisclient/tests/cli/test_endpoint_networks.py
@@ -1,0 +1,104 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from cliff import lister
+from unittest import mock
+
+from coriolisclient.cli import endpoint_networks
+from coriolisclient.cli import utils as cli_utils
+from coriolisclient.tests import test_base
+
+
+class EndpointNetworkFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Endpoint Networks Formatter."""
+
+    def setUp(self):
+        super(EndpointNetworkFormatterTestCase, self).setUp()
+        self.endpoint = endpoint_networks.EndpointNetworkFormatter()
+
+    def test_get_sorted_list(self):
+        obj1 = mock.Mock()
+        obj2 = mock.Mock()
+        obj3 = mock.Mock()
+        obj1.name = "app1"
+        obj2.name = "app2"
+        obj3.name = "app3"
+        obj_list = [obj2, obj1, obj3]
+
+        result = self.endpoint._get_sorted_list(obj_list)
+
+        self.assertEqual(
+            [obj1, obj2, obj3],
+            result
+        )
+
+    def test_get_formatted_data(self):
+        obj = mock.Mock()
+        obj.id = mock.sentinel.id
+        obj.name = mock.sentinel.name
+
+        result = self.endpoint._get_formatted_data(obj)
+
+        self.assertEqual(
+            (
+                mock.sentinel.id,
+                mock.sentinel.name,
+            ),
+            result
+        )
+
+
+class ListEndpointNetworkTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client List Endpoint Networks."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ListEndpointNetworkTestCase, self).setUp()
+        self.endpoint = endpoint_networks.ListEndpointNetwork(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(cli_utils, 'add_args_for_json_option_to_parser')
+    @mock.patch.object(lister.Lister, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+        mock_add_args_for_json_option_to_parser
+    ):
+        result = self.endpoint.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+        mock_add_args_for_json_option_to_parser.assert_called_once_with(
+            mock_get_parser.return_value, 'environment')
+
+    @mock.patch.object(endpoint_networks.EndpointNetworkFormatter,
+                       'list_objects')
+    @mock.patch.object(cli_utils, 'get_option_value_from_args')
+    def test_take_action(
+        self,
+        mock_get_option_value_from_args,
+        mock_list_objects
+    ):
+        args = mock.Mock()
+        args.options = mock.sentinel.options
+        mock_endpoints = mock.Mock()
+        mock_en = mock.Mock()
+        self.mock_app.client_manager.coriolis.endpoints = mock_endpoints
+        mock_en = self.mock_app.client_manager.coriolis.endpoint_networks
+
+        result = self.endpoint.take_action(args)
+
+        self.assertEqual(
+            mock_list_objects.return_value,
+            result
+        )
+        mock_get_option_value_from_args.assert_called_once_with(
+            args, 'environment', error_on_no_value=False)
+        mock_en.list.assert_called_once_with(
+            mock_endpoints.get_endpoint_id_for_name(args.endpoint),
+            mock_get_option_value_from_args.return_value
+        )
+        mock_list_objects.assert_called_once_with(mock_en.list.return_value)

--- a/coriolisclient/tests/cli/test_endpoint_source_minion_pool_options.py
+++ b/coriolisclient/tests/cli/test_endpoint_source_minion_pool_options.py
@@ -1,0 +1,121 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from cliff import lister
+from unittest import mock
+
+from coriolisclient.cli import endpoint_source_minion_pool_options
+from coriolisclient.cli import utils as cli_utils
+from coriolisclient.tests import test_base
+
+
+class EndpointSourceMinionPoolOptionsFormatterTestCase(
+        test_base.CoriolisBaseTestCase):
+    """
+    Test suite for the Coriolis Client Endpoint Source Minion Pool Options
+    Formatter.
+    """
+
+    def setUp(self):
+        super(EndpointSourceMinionPoolOptionsFormatterTestCase, self).setUp()
+        self.endpoint = (endpoint_source_minion_pool_options.
+                         EndpointSourceMinionPoolOptionsFormatter)()
+
+    def test_get_sorted_list(self):
+        obj1 = mock.Mock()
+        obj2 = mock.Mock()
+        obj3 = mock.Mock()
+        obj1.name = "app1"
+        obj2.name = "app2"
+        obj3.name = "app3"
+        obj_list = [obj2, obj1, obj3]
+
+        result = self.endpoint._get_sorted_list(obj_list)
+
+        self.assertEqual(
+            [obj1, obj2, obj3],
+            result
+        )
+
+    @mock.patch.object(cli_utils, 'format_json_for_object_property')
+    def test_get_formatted_data(self, mock_format_json_for_object_property):
+        obj = mock.Mock()
+        obj.name = mock.sentinel.name
+        obj.to_dict = mock.Mock(
+            return_value={"config_default": mock.sentinel.config_default}
+        )
+
+        result = self.endpoint._get_formatted_data(obj)
+
+        self.assertEqual(
+            (
+                mock.sentinel.name,
+                mock_format_json_for_object_property.return_value,
+                mock.sentinel.config_default
+            ),
+            result
+        )
+
+
+class ListEndpointSourceMinionPoolOptionsTestCase(
+        test_base.CoriolisBaseTestCase):
+    """
+    Test suite for the Coriolis Client List Endpoint Source Minion Pool
+    Options.
+    """
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ListEndpointSourceMinionPoolOptionsTestCase, self).setUp()
+        self.endpoint = (endpoint_source_minion_pool_options.
+                         ListEndpointSourceMinionPoolOptions)(
+                             self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(cli_utils, 'add_args_for_json_option_to_parser')
+    @mock.patch.object(lister.Lister, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+        mock_add_args_for_json_option_to_parser
+    ):
+        result = self.endpoint.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+        mock_add_args_for_json_option_to_parser.assert_called_once_with(
+            mock_get_parser.return_value, 'environment')
+
+    @mock.patch.object(endpoint_source_minion_pool_options.
+                       EndpointSourceMinionPoolOptionsFormatter,
+                       'list_objects')
+    @mock.patch.object(cli_utils, 'get_option_value_from_args')
+    def test_take_action(
+        self,
+        mock_get_option_value_from_args,
+        mock_list_objects
+    ):
+        args = mock.Mock()
+        args.options = mock.sentinel.options
+        mock_endpoints = mock.Mock()
+        mock_empso = mock.Mock()
+        self.mock_app.client_manager.coriolis.endpoints = mock_endpoints
+        mock_empso = (self.mock_app.client_manager.coriolis.
+                      endpoint_source_minion_pool_options)
+
+        result = self.endpoint.take_action(args)
+
+        self.assertEqual(
+            mock_list_objects.return_value,
+            result
+        )
+        mock_get_option_value_from_args.assert_called_once_with(
+            args, 'environment', error_on_no_value=False)
+        mock_empso.list.assert_called_once_with(
+            mock_endpoints.get_endpoint_id_for_name(args.endpoint),
+            environment=mock_get_option_value_from_args.return_value,
+            option_names=mock.sentinel.options
+        )
+        mock_list_objects.assert_called_once_with(mock_empso.list.return_value)

--- a/coriolisclient/tests/cli/test_endpoint_source_options.py
+++ b/coriolisclient/tests/cli/test_endpoint_source_options.py
@@ -1,0 +1,110 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from cliff import lister
+from unittest import mock
+
+from coriolisclient.cli import endpoint_source_options
+from coriolisclient.cli import utils as cli_utils
+from coriolisclient.tests import test_base
+
+
+class EndpointSourceOptionFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Endpoint Source Option Formatter."""
+
+    def setUp(self):
+        super(EndpointSourceOptionFormatterTestCase, self).setUp()
+        self.endpoint = endpoint_source_options.EndpointSourceOptionFormatter()
+
+    def test_get_sorted_list(self):
+        obj1 = mock.Mock()
+        obj2 = mock.Mock()
+        obj3 = mock.Mock()
+        obj1.name = "app1"
+        obj2.name = "app2"
+        obj3.name = "app3"
+        obj_list = [obj2, obj1, obj3]
+
+        result = self.endpoint._get_sorted_list(obj_list)
+
+        self.assertEqual(
+            [obj1, obj2, obj3],
+            result
+        )
+
+    @mock.patch.object(cli_utils, 'format_json_for_object_property')
+    def test_get_formatted_data(self, mock_format_json_for_object_property):
+        obj = mock.Mock()
+        obj.name = mock.sentinel.name
+        obj.to_dict = mock.Mock(
+            return_value={"config_default": mock.sentinel.config_default}
+        )
+
+        result = self.endpoint._get_formatted_data(obj)
+
+        self.assertEqual(
+            (
+                mock.sentinel.name,
+                mock_format_json_for_object_property.return_value,
+                mock.sentinel.config_default
+            ),
+            result
+        )
+
+
+class ListEndpointSourceOptionsTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client List Endpoint Source Options."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ListEndpointSourceOptionsTestCase, self).setUp()
+        self.endpoint = endpoint_source_options.ListEndpointSourceOptions(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(cli_utils, 'add_args_for_json_option_to_parser')
+    @mock.patch.object(lister.Lister, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+        mock_add_args_for_json_option_to_parser
+    ):
+        result = self.endpoint.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+        mock_add_args_for_json_option_to_parser.assert_called_once_with(
+            mock_get_parser.return_value, 'environment')
+
+    @mock.patch.object(endpoint_source_options.EndpointSourceOptionFormatter,
+                       'list_objects')
+    @mock.patch.object(cli_utils, 'get_option_value_from_args')
+    def test_take_action(
+        self,
+        mock_get_option_value_from_args,
+        mock_list_objects
+    ):
+        args = mock.Mock()
+        args.options = mock.sentinel.options
+        mock_endpoints = mock.Mock()
+        mock_edo = mock.Mock()
+        self.mock_app.client_manager.coriolis.endpoints = mock_endpoints
+        mock_edo = (self.mock_app.
+                    client_manager.coriolis.endpoint_source_options)
+
+        result = self.endpoint.take_action(args)
+
+        self.assertEqual(
+            mock_list_objects.return_value,
+            result
+        )
+        mock_get_option_value_from_args.assert_called_once_with(
+            args, 'environment', error_on_no_value=False)
+        mock_edo.list.assert_called_once_with(
+            mock_endpoints.get_endpoint_id_for_name(args.endpoint),
+            environment=mock_get_option_value_from_args.return_value,
+            option_names=mock.sentinel.options
+        )
+        mock_list_objects.assert_called_once_with(mock_edo.list.return_value)

--- a/coriolisclient/tests/cli/test_endpoint_storage.py
+++ b/coriolisclient/tests/cli/test_endpoint_storage.py
@@ -1,0 +1,107 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from cliff import lister
+from unittest import mock
+
+from coriolisclient.cli import endpoint_storage
+from coriolisclient.cli import utils as cli_utils
+from coriolisclient.tests import test_base
+
+
+class EndpointStorageFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Endpoint Storage Formatter."""
+
+    def setUp(self):
+        super(EndpointStorageFormatterTestCase, self).setUp()
+        self.endpoint = endpoint_storage.EndpointStorageFormatter()
+
+    def test_get_sorted_list(self):
+        obj1 = mock.Mock()
+        obj2 = mock.Mock()
+        obj3 = mock.Mock()
+        obj1.name = "app1"
+        obj2.name = "app2"
+        obj3.name = "app3"
+        obj_list = [obj2, obj1, obj3]
+
+        result = self.endpoint._get_sorted_list(obj_list)
+
+        self.assertEqual(
+            [obj1, obj2, obj3],
+            result
+        )
+
+    def test_get_formatted_data(self):
+        obj = mock.Mock()
+        obj.id = mock.sentinel.id
+        obj.name = mock.sentinel.name
+        obj.additional_provider_properties = \
+            mock.sentinel.additional_provider_properties
+
+        result = self.endpoint._get_formatted_data(obj)
+
+        self.assertEqual(
+            (
+                mock.sentinel.id,
+                mock.sentinel.name,
+                mock.sentinel.additional_provider_properties
+            ),
+            result
+        )
+
+
+class ListEndpointStorageTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client List Endpoint Storage."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ListEndpointStorageTestCase, self).setUp()
+        self.endpoint = endpoint_storage.ListEndpointStorage(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(cli_utils, 'add_args_for_json_option_to_parser')
+    @mock.patch.object(lister.Lister, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+        mock_add_args_for_json_option_to_parser
+    ):
+        result = self.endpoint.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+        mock_add_args_for_json_option_to_parser.assert_called_once_with(
+            mock_get_parser.return_value, 'environment')
+
+    @mock.patch.object(endpoint_storage.EndpointStorageFormatter,
+                       'list_objects')
+    @mock.patch.object(cli_utils, 'get_option_value_from_args')
+    def test_take_action(
+        self,
+        mock_get_option_value_from_args,
+        mock_list_objects
+    ):
+        args = mock.Mock()
+        args.options = mock.sentinel.options
+        mock_endpoints = mock.Mock()
+        mock_es = mock.Mock()
+        self.mock_app.client_manager.coriolis.endpoints = mock_endpoints
+        mock_es = self.mock_app.client_manager.coriolis.endpoint_storage
+
+        result = self.endpoint.take_action(args)
+
+        self.assertEqual(
+            mock_list_objects.return_value,
+            result
+        )
+        mock_get_option_value_from_args.assert_called_once_with(
+            args, 'environment', error_on_no_value=False)
+        mock_es.list.assert_called_once_with(
+            mock_endpoints.get_endpoint_id_for_name(args.endpoint),
+            environment=mock_get_option_value_from_args.return_value
+        )
+        mock_list_objects.assert_called_once_with(mock_es.list.return_value)

--- a/coriolisclient/tests/cli/test_endpoints.py
+++ b/coriolisclient/tests/cli/test_endpoints.py
@@ -1,0 +1,535 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from cliff import command
+from cliff import lister
+from cliff import show
+import ddt
+from unittest import mock
+
+from coriolisclient.cli import endpoints
+from coriolisclient import exceptions
+from coriolisclient.tests import test_base
+
+
+@ddt.ddt
+class EndpointTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Endpoints."""
+
+    def test_add_connection_info_args_to_parser(self):
+        mock_parser = mock.Mock()
+        mock_add_argument = mock.Mock()
+        mock_parser.add_mutually_exclusive_group.return_value.add_argument = \
+            mock_add_argument
+
+        result = endpoints.add_connection_info_args_to_parser(mock_parser)
+
+        self.assertEqual(
+            mock_parser,
+            result
+        )
+        mock_parser.add_mutually_exclusive_group.assert_called_once()
+
+    @ddt.data(
+        {"conn": (None, None, None), "expected_result": None,
+         "raise_if_none": False},
+        {"conn": (None, None, None), "expected_result": "exception"},
+        {
+            "conn": ('{"conn_info": "mock_conn_info"}', None, None),
+            "expected_result": {"conn_info": "mock_conn_info"}
+        },
+        {
+            "conn": (None, '{"conn_info": "mock_conn_info"}', None),
+            "expected_result": {"conn_info": "mock_conn_info"}
+        },
+        {
+            "conn": (None, 'invalid', None),
+            "expected_result": "exception"
+        },
+        {
+            "conn": (None, None, "mock_secret"),
+            "expected_result": {"secret_ref": "mock_secret"}
+        },
+    )
+    def test_get_connnection_info_from_args(self, data):
+        mock_args = mock.MagicMock()
+        (mock_args.connection,
+            mock_args.connection_file.__enter__.return_value.read.return_value,
+            mock_args.connection_secret) = data["conn"]
+        if data["conn"][1] is None:
+            mock_args.connection_file = None
+
+        if data["expected_result"] == "exception":
+            self.assertRaises(
+                ValueError,
+                endpoints.get_connnection_info_from_args,
+                mock_args
+            )
+        else:
+            result = endpoints.get_connnection_info_from_args(
+                mock_args, raise_if_none=data.get("raise_if_none", True))
+
+            self.assertEqual(
+                data["expected_result"],
+                result
+            )
+
+
+class EndpointFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Endpoint Formatter."""
+
+    def setUp(self):
+        super(EndpointFormatterTestCase, self).setUp()
+        self.endpoint = endpoints.EndpointFormatter()
+
+    def test_get_sorted_list(self):
+        obj1 = mock.Mock()
+        obj2 = mock.Mock()
+        obj3 = mock.Mock()
+        obj1.created_at = "date1"
+        obj2.created_at = "date2"
+        obj3.created_at = "date3"
+        obj_list = [obj2, obj1, obj3]
+
+        result = self.endpoint._get_sorted_list(obj_list)
+
+        self.assertEqual(
+            [obj1, obj2, obj3],
+            result
+        )
+
+    def test_get_formatted_data(self):
+        obj = mock.Mock()
+        obj.id = mock.sentinel.id
+        obj.name = mock.sentinel.name
+        obj.type = mock.sentinel.type
+        obj.description = mock.sentinel.description
+        obj.mapped_regions = mock.sentinel.mapped_regions
+
+        result = self.endpoint._get_formatted_data(obj)
+
+        self.assertEqual(
+            (
+                mock.sentinel.id,
+                mock.sentinel.name,
+                mock.sentinel.type,
+                mock.sentinel.description,
+                mock.sentinel.mapped_regions
+            ),
+            result
+        )
+
+
+class EndpointDetailFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Endpoint Detail Formatter."""
+
+    def setUp(self):
+        super(EndpointDetailFormatterTestCase, self).setUp()
+        self.endpoint = endpoints.EndpointDetailFormatter()
+
+    def test_get_formatted_data(self):
+        obj = mock.Mock()
+        obj.id = mock.sentinel.id
+        obj.name = mock.sentinel.name
+        obj.type = mock.sentinel.type
+        obj.description = mock.sentinel.description
+        obj.mapped_regions = mock.sentinel.mapped_regions
+        obj.created_at = mock.sentinel.created_at
+        obj.updated_at = mock.sentinel.updated_at
+        obj.connection_info.to_dict = mock.Mock(
+            return_value=mock.sentinel.connection_info
+        )
+
+        result = self.endpoint._get_formatted_data(obj)
+
+        self.assertEqual(
+            [
+                mock.sentinel.id,
+                mock.sentinel.name,
+                mock.sentinel.type,
+                mock.sentinel.description,
+                mock.sentinel.connection_info,
+                mock.sentinel.mapped_regions,
+                mock.sentinel.created_at,
+                mock.sentinel.updated_at
+            ],
+            result
+        )
+
+
+class CreateEndpointTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Create Endpoint."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(CreateEndpointTestCase, self).setUp()
+        self.endpoint = endpoints.CreateEndpoint(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(endpoints, 'add_connection_info_args_to_parser')
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+        mock_add_connection_info_args_to_parser
+    ):
+        result = self.endpoint.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+        mock_add_connection_info_args_to_parser.assert_called_once_with(
+            mock_get_parser.return_value)
+
+    @mock.patch.object(endpoints.EndpointDetailFormatter,
+                       'get_formatted_entity')
+    @mock.patch.object(endpoints, 'get_connnection_info_from_args')
+    def test_take_action(
+        self,
+        mock_get_connnection_info_from_args,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.connection_secret = mock.sentinel.connection_secret
+        args.connection = None
+        args.name = mock.sentinel.name
+        args.provider = mock.sentinel.provider
+        args.description = mock.sentinel.description
+        args.regions = mock.sentinel.regions
+        args.skip_validation = False
+        mock_create = mock.Mock()
+        mock_validate_connection = mock.Mock()
+        mock_validate_connection.return_value = (True, "mock_message")
+        self.mock_app.client_manager.coriolis.endpoints.create = mock_create
+        self.mock_app.client_manager.coriolis.endpoints.validate_connection = \
+            mock_validate_connection
+
+        result = self.endpoint.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_get_connnection_info_from_args.assert_called_once_with(args)
+        mock_create.assert_called_once_with(
+            mock.sentinel.name,
+            mock.sentinel.provider,
+            mock_get_connnection_info_from_args.return_value,
+            mock.sentinel.description,
+            regions=mock.sentinel.regions,
+        )
+        mock_validate_connection.assert_called_once_with(
+            mock_create.return_value.id)
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_create.return_value)
+
+    def test_take_action_raises_connection(self):
+        args = mock.Mock()
+        args.connection_secret = mock.sentinel.connection_secret
+        args.connection = mock.sentinel.connection
+
+        self.assertRaises(
+            exceptions.CoriolisException,
+            self.endpoint.take_action,
+            args
+        )
+
+    @mock.patch.object(endpoints.EndpointDetailFormatter,
+                       'get_formatted_entity')
+    @mock.patch.object(endpoints, 'get_connnection_info_from_args')
+    def test_take_action_validation_failed(
+        self,
+        mock_get_connnection_info_from_args,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.connection_secret = mock.sentinel.connection_secret
+        args.connection = None
+        args.name = mock.sentinel.name
+        args.provider = mock.sentinel.provider
+        args.description = mock.sentinel.description
+        args.regions = mock.sentinel.regions
+        args.skip_validation = False
+        mock_create = mock.Mock()
+        mock_validate_connection = mock.Mock()
+        mock_validate_connection.return_value = (False, "mock_message")
+        self.mock_app.client_manager.coriolis.endpoints.create = mock_create
+        self.mock_app.client_manager.coriolis.endpoints.validate_connection = \
+            mock_validate_connection
+
+        self.assertRaises(
+            exceptions.EndpointConnectionValidationFailed,
+            self.endpoint.take_action,
+            args
+        )
+
+        mock_get_connnection_info_from_args.assert_called_once_with(args)
+        mock_create.assert_called_once_with(
+            mock.sentinel.name,
+            mock.sentinel.provider,
+            mock_get_connnection_info_from_args.return_value,
+            mock.sentinel.description,
+            regions=mock.sentinel.regions,
+        )
+        mock_validate_connection.assert_called_once_with(
+            mock_create.return_value.id)
+        mock_get_formatted_entity.assert_not_called()
+
+
+class UpdateEndpointTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Update Endpoint."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(UpdateEndpointTestCase, self).setUp()
+        self.endpoint = endpoints.UpdateEndpoint(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(endpoints, 'add_connection_info_args_to_parser')
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+        mock_add_connection_info_args_to_parser
+    ):
+        result = self.endpoint.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+        mock_add_connection_info_args_to_parser.assert_called_once_with(
+            mock_get_parser.return_value)
+
+    @mock.patch.object(endpoints.EndpointDetailFormatter,
+                       'get_formatted_entity')
+    @mock.patch.object(endpoints, 'get_connnection_info_from_args')
+    def test_take_action(
+        self,
+        mock_get_connnection_info_from_args,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.connection_secret = mock.sentinel.connection_secret
+        args.connection = None
+        args.id = mock.sentinel.id
+        args.name = mock.sentinel.name
+        args.description = mock.sentinel.description
+        args.regions = mock.sentinel.regions
+        args.skip_validation = False
+        mock_update = mock.Mock()
+        self.mock_app.client_manager.coriolis.endpoints.update = mock_update
+        expected_updated_values = {
+            "name": mock.sentinel.name,
+            "description": mock.sentinel.description,
+            "connection_info": (mock_get_connnection_info_from_args.
+                                return_value),
+            "mapped_regions": mock.sentinel.regions,
+        }
+
+        result = self.endpoint.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_get_connnection_info_from_args.assert_called_once_with(
+            args, raise_if_none=False)
+        mock_update.assert_called_once_with(
+            mock.sentinel.id,
+            expected_updated_values,
+        )
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_update.return_value)
+
+    def test_take_action_raises_connection(self):
+        args = mock.Mock()
+        args.connection_secret = mock.sentinel.connection_secret
+        args.connection = mock.sentinel.connection
+
+        self.assertRaises(
+            exceptions.CoriolisException,
+            self.endpoint.take_action,
+            args
+        )
+
+
+class ShowEndpointTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Show Endpoint."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ShowEndpointTestCase, self).setUp()
+        self.endpoint = endpoints.ShowEndpoint(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.endpoint.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(endpoints.EndpointDetailFormatter,
+                       'get_formatted_entity')
+    def test_take_action(
+        self,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        mock_client = mock.Mock()
+        args.id = mock.sentinel.id
+        self.mock_app.client_manager.coriolis.endpoints = mock_client
+
+        result = self.endpoint.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_client.get_endpoint_id_for_name.assert_called_once_with(
+            mock.sentinel.id)
+        mock_client.get.assert_called_once_with(
+            mock_client.get_endpoint_id_for_name.return_value)
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_client.get.return_value)
+
+
+class DeleteEndpointTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Delete Endpoint."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(DeleteEndpointTestCase, self).setUp()
+        self.endpoint = endpoints.DeleteEndpoint(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(command.Command, 'get_parser')
+    def test_get_parser(self, mock_get_parser):
+        result = self.endpoint.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    def test_take_action(self):
+        args = mock.Mock()
+        mock_client = mock.Mock()
+        args.id = mock.sentinel.id
+        self.mock_app.client_manager.coriolis.endpoints = mock_client
+
+        self.endpoint.take_action(args)
+
+        mock_client.get_endpoint_id_for_name.assert_called_once_with(
+            mock.sentinel.id)
+        mock_client.delete.assert_called_once_with(
+            mock_client.get_endpoint_id_for_name.return_value)
+
+
+class ListEndpointTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client List Endpoint."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ListEndpointTestCase, self).setUp()
+        self.endpoint = endpoints.ListEndpoint(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(lister.Lister, 'get_parser')
+    def test_get_parser(self, mock_get_parser):
+        result = self.endpoint.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(endpoints.EndpointFormatter, 'list_objects')
+    def test_take_action(self, mock_list_objects):
+        args = mock.Mock()
+        mock_client = mock.Mock()
+        self.mock_app.client_manager.coriolis.endpoints = mock_client
+
+        result = self.endpoint.take_action(args)
+
+        self.assertEqual(
+            mock_list_objects.return_value,
+            result
+        )
+
+        mock_client.list.assert_called_once()
+        mock_list_objects.assert_called_once_with(
+            mock_client.list.return_value)
+
+
+class EndpointValidateConnectionTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client List Endpoint."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(EndpointValidateConnectionTestCase, self).setUp()
+        self.endpoint = endpoints.EndpointValidateConnection(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(command.Command, 'get_parser')
+    def test_get_parser(self, mock_get_parser):
+        result = self.endpoint.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(endpoints.EndpointFormatter, 'list_objects')
+    def test_take_action(self, mock_list_objects):
+        args = mock.Mock()
+        mock_endpoint = mock.Mock()
+        args.id = mock.sentinel.id
+        self.mock_app.client_manager.coriolis.endpoints = mock_endpoint
+        mock_validate_connection = mock.Mock()
+        mock_validate_connection.return_value = (True, "mock_message")
+        self.mock_app.client_manager.coriolis.endpoints.validate_connection = \
+            mock_validate_connection
+
+        self.endpoint.take_action(args)
+
+        mock_endpoint.get_endpoint_id_for_name.assert_called_once_with(
+            mock.sentinel.id)
+        mock_validate_connection.assert_called_once_with(
+            mock_endpoint.get_endpoint_id_for_name.return_value)
+
+    @mock.patch.object(endpoints.EndpointFormatter, 'list_objects')
+    def test_take_action_not_valid(self, mock_list_objects):
+        args = mock.Mock()
+        mock_endpoint = mock.Mock()
+        args.id = mock.sentinel.id
+        self.mock_app.client_manager.coriolis.endpoints = mock_endpoint
+        mock_validate_connection = mock.Mock()
+        mock_validate_connection.return_value = (False, "mock_message")
+        self.mock_app.client_manager.coriolis.endpoints.validate_connection = \
+            mock_validate_connection
+
+        self.assertRaisesRegex(
+            exceptions.EndpointConnectionValidationFailed,
+            "mock_message",
+            self.endpoint.take_action,
+            args
+        )
+
+        mock_endpoint.get_endpoint_id_for_name.assert_called_once_with(
+            mock.sentinel.id)
+        mock_validate_connection.assert_called_once_with(
+            mock_endpoint.get_endpoint_id_for_name.return_value)

--- a/coriolisclient/tests/cli/test_endpoints.py
+++ b/coriolisclient/tests/cli/test_endpoints.py
@@ -51,7 +51,7 @@ class EndpointTestCase(test_base.CoriolisBaseTestCase):
             "expected_result": {"secret_ref": "mock_secret"}
         },
     )
-    def test_get_connnection_info_from_args(self, data):
+    def test_get_connection_info_from_args(self, data):
         mock_args = mock.MagicMock()
         (mock_args.connection,
             mock_args.connection_file.__enter__.return_value.read.return_value,
@@ -62,11 +62,11 @@ class EndpointTestCase(test_base.CoriolisBaseTestCase):
         if data["expected_result"] == "exception":
             self.assertRaises(
                 ValueError,
-                endpoints.get_connnection_info_from_args,
+                endpoints.get_connection_info_from_args,
                 mock_args
             )
         else:
-            result = endpoints.get_connnection_info_from_args(
+            result = endpoints.get_connection_info_from_args(
                 mock_args, raise_if_none=data.get("raise_if_none", True))
 
             self.assertEqual(
@@ -185,10 +185,10 @@ class CreateEndpointTestCase(test_base.CoriolisBaseTestCase):
 
     @mock.patch.object(endpoints.EndpointDetailFormatter,
                        'get_formatted_entity')
-    @mock.patch.object(endpoints, 'get_connnection_info_from_args')
+    @mock.patch.object(endpoints, 'get_connection_info_from_args')
     def test_take_action(
         self,
-        mock_get_connnection_info_from_args,
+        mock_get_connection_info_from_args,
         mock_get_formatted_entity
     ):
         args = mock.Mock()
@@ -212,11 +212,11 @@ class CreateEndpointTestCase(test_base.CoriolisBaseTestCase):
             mock_get_formatted_entity.return_value,
             result
         )
-        mock_get_connnection_info_from_args.assert_called_once_with(args)
+        mock_get_connection_info_from_args.assert_called_once_with(args)
         mock_create.assert_called_once_with(
             mock.sentinel.name,
             mock.sentinel.provider,
-            mock_get_connnection_info_from_args.return_value,
+            mock_get_connection_info_from_args.return_value,
             mock.sentinel.description,
             regions=mock.sentinel.regions,
         )
@@ -238,10 +238,10 @@ class CreateEndpointTestCase(test_base.CoriolisBaseTestCase):
 
     @mock.patch.object(endpoints.EndpointDetailFormatter,
                        'get_formatted_entity')
-    @mock.patch.object(endpoints, 'get_connnection_info_from_args')
+    @mock.patch.object(endpoints, 'get_connection_info_from_args')
     def test_take_action_validation_failed(
         self,
-        mock_get_connnection_info_from_args,
+        mock_get_connection_info_from_args,
         mock_get_formatted_entity
     ):
         args = mock.Mock()
@@ -265,11 +265,11 @@ class CreateEndpointTestCase(test_base.CoriolisBaseTestCase):
             args
         )
 
-        mock_get_connnection_info_from_args.assert_called_once_with(args)
+        mock_get_connection_info_from_args.assert_called_once_with(args)
         mock_create.assert_called_once_with(
             mock.sentinel.name,
             mock.sentinel.provider,
-            mock_get_connnection_info_from_args.return_value,
+            mock_get_connection_info_from_args.return_value,
             mock.sentinel.description,
             regions=mock.sentinel.regions,
         )
@@ -306,10 +306,10 @@ class UpdateEndpointTestCase(test_base.CoriolisBaseTestCase):
 
     @mock.patch.object(endpoints.EndpointDetailFormatter,
                        'get_formatted_entity')
-    @mock.patch.object(endpoints, 'get_connnection_info_from_args')
+    @mock.patch.object(endpoints, 'get_connection_info_from_args')
     def test_take_action(
         self,
-        mock_get_connnection_info_from_args,
+        mock_get_connection_info_from_args,
         mock_get_formatted_entity
     ):
         args = mock.Mock()
@@ -325,7 +325,7 @@ class UpdateEndpointTestCase(test_base.CoriolisBaseTestCase):
         expected_updated_values = {
             "name": mock.sentinel.name,
             "description": mock.sentinel.description,
-            "connection_info": (mock_get_connnection_info_from_args.
+            "connection_info": (mock_get_connection_info_from_args.
                                 return_value),
             "mapped_regions": mock.sentinel.regions,
         }
@@ -336,7 +336,7 @@ class UpdateEndpointTestCase(test_base.CoriolisBaseTestCase):
             mock_get_formatted_entity.return_value,
             result
         )
-        mock_get_connnection_info_from_args.assert_called_once_with(
+        mock_get_connection_info_from_args.assert_called_once_with(
             args, raise_if_none=False)
         mock_update.assert_called_once_with(
             mock.sentinel.id,


### PR DESCRIPTION
This PR adds unit tests for `coriolisclient.cli.endpoint*` modules.