### PR TITLE
Add unit tests for `coriolisclient.cli.*` modules

### DIFF
--- a/coriolisclient/tests/cli/test_licensing.py
+++ b/coriolisclient/tests/cli/test_licensing.py
@@ -1,0 +1,362 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from unittest import mock
+
+from cliff import command
+from cliff import lister
+from cliff import show
+
+from coriolisclient.cli import licensing
+from coriolisclient.tests import test_base
+
+
+class LicensingStatusFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Licensing Status Formatter."""
+
+    def setUp(self):
+        super(LicensingStatusFormatterTestCase, self).setUp()
+        self.licence = licensing.LicensingStatusFormatter()
+
+    def test_get_formatted_data(self):
+        obj = mock.Mock()
+        obj.appliance_id = mock.sentinel.appliance_id
+        obj.earliest_licence_expiry_time = \
+            mock.sentinel.earliest_licence_expiry_time
+        obj.latest_licence_expiry_time = \
+            mock.sentinel.latest_licence_expiry_time
+        obj.current_performed_migrations = \
+            mock.sentinel.current_performed_migrations
+        obj.current_performed_replicas = \
+            mock.sentinel.current_performed_replicas
+        obj.current_available_migrations = \
+            mock.sentinel.current_available_migrations
+        obj.current_available_replicas = \
+            mock.sentinel.current_available_replicas
+        obj.lifetime_performed_migrations = \
+            mock.sentinel.lifetime_performed_migrations
+        obj.lifetime_performed_replicas = \
+            mock.sentinel.lifetime_performed_replicas
+        obj.lifetime_available_migrations = \
+            mock.sentinel.lifetime_available_migrations
+        obj.lifetime_available_replicas = \
+            mock.sentinel.lifetime_available_replicas
+
+        result = self.licence._get_formatted_data(obj)
+
+        self.assertEqual(
+            [
+                mock.sentinel.appliance_id,
+                mock.sentinel.earliest_licence_expiry_time,
+                mock.sentinel.latest_licence_expiry_time,
+                mock.sentinel.current_performed_migrations,
+                mock.sentinel.current_performed_replicas,
+                mock.sentinel.current_available_migrations,
+                mock.sentinel.current_available_replicas,
+                mock.sentinel.lifetime_performed_migrations,
+                mock.sentinel.lifetime_performed_replicas,
+                mock.sentinel.lifetime_available_migrations,
+                mock.sentinel.lifetime_available_replicas
+            ],
+            result
+        )
+
+
+class LicenceFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Licence Formatter."""
+
+    def setUp(self):
+        super(LicenceFormatterTestCase, self).setUp()
+        self.licence = licensing.LicenceFormatter()
+
+    def test_get_sorted_list(self):
+        obj1 = mock.Mock()
+        obj2 = mock.Mock()
+        obj3 = mock.Mock()
+        obj1.period_end = "period_end1"
+        obj2.period_end = "period_end2"
+        obj3.period_end = "period_end3"
+        obj_list = [obj2, obj1, obj3]
+
+        result = self.licence._get_sorted_list(obj_list)
+
+        self.assertEqual(
+            [obj1, obj2, obj3],
+            result
+        )
+
+    def test_get_formatted_data(self):
+        obj = mock.Mock()
+        obj.id = mock.sentinel.id
+        obj.issue_date = mock.sentinel.issue_date
+        obj.migrations = mock.sentinel.migrations
+        obj.replicas = mock.sentinel.replicas
+        obj.period_start = mock.sentinel.period_start
+        obj.period_end = mock.sentinel.period_end
+        obj.period_duration = mock.sentinel.period_duration
+        obj.licence_version = mock.sentinel.licence_version
+
+        result = self.licence._get_formatted_data(obj)
+
+        self.assertEqual(
+            (
+                mock.sentinel.id,
+                mock.sentinel.issue_date,
+                mock.sentinel.migrations,
+                mock.sentinel.replicas,
+                mock.sentinel.period_start,
+                mock.sentinel.period_end,
+                mock.sentinel.period_duration,
+                mock.sentinel.licence_version
+            ),
+            result
+        )
+
+
+class LicensingApplianceStatusTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Licensing Appliance Status."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(LicensingApplianceStatusTestCase, self).setUp()
+        self.licence = licensing.LicensingApplianceStatus(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.licence.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(licensing.LicensingStatusFormatter,
+                       'get_formatted_entity')
+    def test_take_action(
+        self,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.appliance_id = mock.sentinel.appliance_id
+        mock_lic_status = mock.Mock()
+        self.mock_app.client_manager.coriolis.licensing.status = \
+            mock_lic_status
+
+        result = self.licence.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_lic_status.assert_called_once_with(mock.sentinel.appliance_id)
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_lic_status.return_value)
+
+
+class LicenceRegisterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Licence Register."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(LicenceRegisterTestCase, self).setUp()
+        self.licence = licensing.LicenceRegister(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.licence.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(licensing.LicenceFormatter, 'get_formatted_entity')
+    def test_take_action_raw_arg(
+        self,
+        mock_get_formatted_entity
+    ):
+        args = mock.MagicMock()
+        args.licence_pem = mock.sentinel.licence_pem
+        args.licence_pem_file.__enter__.return_value.read.return_value = \
+            mock.sentinel.licence_pem_file
+        mock_licence = mock.Mock()
+        self.mock_app.client_manager.coriolis.licensing.register = mock_licence
+
+        result = self.licence.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_licence.assert_called_once_with(
+            args.appliance_id, mock.sentinel.licence_pem)
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_licence.return_value)
+
+    @mock.patch.object(licensing.LicenceFormatter, 'get_formatted_entity')
+    def test_take_action_file_arg(
+        self,
+        mock_get_formatted_entity
+    ):
+        args = mock.MagicMock()
+        args.licence_pem = None
+        args.licence_pem_file.__enter__.return_value.read.return_value = \
+            mock.sentinel.licence_pem_file
+        mock_licence = mock.Mock()
+        self.mock_app.client_manager.coriolis.licensing.register = mock_licence
+
+        result = self.licence.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_licence.assert_called_once_with(
+            args.appliance_id, mock.sentinel.licence_pem_file)
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_licence.return_value)
+
+    def test_take_action_value_error(self):
+        args = mock.MagicMock()
+        args.licence_pem = None
+        args.licence_pem_file = None
+        mock_licence = mock.Mock()
+        self.mock_app.client_manager.coriolis.licensing.register = mock_licence
+
+        self.assertRaises(
+            ValueError,
+            self.licence.take_action,
+            args
+        )
+
+        mock_licence.assert_not_called()
+
+
+class LicenceListTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Licence List."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(LicenceListTestCase, self).setUp()
+        self.licence = licensing.LicenceList(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(lister.Lister, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.licence.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(licensing.LicenceFormatter, 'list_objects')
+    def test_take_action(
+        self,
+        mock_list_objects
+    ):
+        args = mock.Mock()
+        args.appliance_id = mock.sentinel.appliance_id
+        mock_lic_list = mock.Mock()
+        self.mock_app.client_manager.coriolis.licensing.list = \
+            mock_lic_list
+
+        result = self.licence.take_action(args)
+
+        self.assertEqual(
+            mock_list_objects.return_value,
+            result
+        )
+        mock_lic_list.assert_called_once_with(mock.sentinel.appliance_id)
+        mock_list_objects.assert_called_once_with(mock_lic_list.return_value)
+
+
+class LicenceShowTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Licence Show."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(LicenceShowTestCase, self).setUp()
+        self.licence = licensing.LicenceShow(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.licence.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(licensing.LicenceFormatter, 'get_formatted_entity')
+    def test_take_action(
+        self,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.appliance_id = mock.sentinel.appliance_id
+        args.licence_id = mock.sentinel.licence_id
+        licence = mock.Mock()
+        self.mock_app.client_manager.coriolis.licensing.show = licence
+
+        result = self.licence.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        licence.assert_called_once_with(args.appliance_id, args.licence_id)
+        mock_get_formatted_entity.assert_called_once_with(licence.return_value)
+
+
+class LicenceDeleteTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Licence Delete."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(LicenceDeleteTestCase, self).setUp()
+        self.licence = licensing.LicenceDelete(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(command.Command, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.licence.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    def test_take_action(self):
+        args = mock.Mock()
+        args.appliance_id = mock.sentinel.appliance_id
+        args.licence_id = mock.sentinel.licence_id
+        licence = mock.Mock()
+        self.mock_app.client_manager.coriolis.licensing.delete = licence
+
+        self.licence.take_action(args)
+
+        licence.assert_called_once_with(args.appliance_id, args.licence_id)

--- a/coriolisclient/tests/cli/test_licensing_appliances.py
+++ b/coriolisclient/tests/cli/test_licensing_appliances.py
@@ -1,0 +1,177 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from unittest import mock
+
+from cliff import lister
+from cliff import show
+
+from coriolisclient.cli import licensing_appliances
+from coriolisclient.tests import test_base
+
+
+class ApplianceFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Appliance Formatter."""
+
+    def setUp(self):
+        super(ApplianceFormatterTestCase, self).setUp()
+        self.appliance = licensing_appliances.ApplianceFormatter()
+
+    def test_get_sorted_list(self):
+        obj1 = mock.Mock()
+        obj2 = mock.Mock()
+        obj3 = mock.Mock()
+        obj1.id = "app1"
+        obj2.id = "app2"
+        obj3.id = "app3"
+        obj_list = [obj2, obj1, obj3]
+
+        result = self.appliance._get_sorted_list(obj_list)
+
+        self.assertEqual(
+            [obj1, obj2, obj3],
+            result
+        )
+
+    def test_get_formatted_data(self):
+        obj = mock.Mock()
+        obj.id = mock.sentinel.id
+
+        result = self.appliance._get_formatted_data(obj)
+
+        self.assertEqual(
+            [mock.sentinel.id],
+            result
+        )
+
+
+class ApplianceListTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Appliance List."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ApplianceListTestCase, self).setUp()
+        self.appliance = licensing_appliances.ApplianceList(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(lister.Lister, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.appliance.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(licensing_appliances.ApplianceFormatter,
+                       'list_objects')
+    def test_take_action(
+        self,
+        mock_list_objects
+    ):
+        args = mock.Mock()
+        mock_licensing_appliances = mock.Mock()
+        self.mock_app.client_manager.coriolis.licensing_appliances = \
+            mock_licensing_appliances
+
+        result = self.appliance.take_action(args)
+
+        self.assertEqual(
+            mock_list_objects.return_value,
+            result
+        )
+        mock_list_objects.assert_called_once_with(
+            mock_licensing_appliances.list.return_value)
+
+
+class ApplianceShowTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Appliance Show."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ApplianceShowTestCase, self).setUp()
+        self.appliance = licensing_appliances.ApplianceShow(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.appliance.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(licensing_appliances.ApplianceFormatter,
+                       'get_formatted_entity')
+    def test_take_action(
+        self,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.appliance_id = mock.sentinel.appliance_id
+        mock_licensing_appliances = mock.Mock()
+        self.mock_app.client_manager.coriolis.licensing_appliances = \
+            mock_licensing_appliances
+
+        result = self.appliance.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_licensing_appliances.show.assert_called_once_with(
+            mock.sentinel.appliance_id)
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_licensing_appliances.show.return_value)
+
+
+class ApplianceCreateTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Appliance Create."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ApplianceCreateTestCase, self).setUp()
+        self.appliance = licensing_appliances.ApplianceCreate(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.appliance.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(licensing_appliances.ApplianceFormatter,
+                       'get_formatted_entity')
+    def test_take_action(
+        self,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        mock_licensing_appliances = mock.Mock()
+        self.mock_app.client_manager.coriolis.licensing_appliances = \
+            mock_licensing_appliances
+
+        result = self.appliance.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_licensing_appliances.create.return_value)

--- a/coriolisclient/tests/cli/test_licensing_reservations.py
+++ b/coriolisclient/tests/cli/test_licensing_reservations.py
@@ -1,0 +1,190 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from unittest import mock
+
+from cliff import lister
+from cliff import show
+
+from coriolisclient.cli import licensing_reservations
+from coriolisclient.tests import test_base
+
+
+class ReservationFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Reservation Formatter."""
+
+    def setUp(self):
+        super(ReservationFormatterTestCase, self).setUp()
+        self.reservation = licensing_reservations.ReservationFormatter()
+
+    def test_get_sorted_list(self):
+        obj1 = mock.Mock()
+        obj2 = mock.Mock()
+        obj3 = mock.Mock()
+        obj1.created_at = "date1"
+        obj2.created_at = "date2"
+        obj3.created_at = "date3"
+        obj_list = [obj2, obj1, obj3]
+
+        result = self.reservation._get_sorted_list(obj_list)
+
+        self.assertEqual(
+            [obj1, obj2, obj3],
+            result
+        )
+
+    def test_get_formatted_data(self):
+        obj = mock.Mock()
+        obj.id = mock.sentinel.id
+        obj.appliance_id = mock.sentinel.appliance_id
+        obj.licence_id = mock.sentinel.licence_id
+        obj.type = mock.sentinel.type
+        obj.count = mock.sentinel.count
+        obj.created_at = mock.sentinel.created_at
+
+        result = self.reservation._get_formatted_data(obj)
+
+        self.assertEqual(
+            (
+                mock.sentinel.id,
+                mock.sentinel.appliance_id,
+                mock.sentinel.licence_id,
+                mock.sentinel.type,
+                mock.sentinel.count,
+                mock.sentinel.created_at
+            ),
+            result
+        )
+
+
+class ReservationListTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Reservation List."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ReservationListTestCase, self).setUp()
+        self.reservation = licensing_reservations.ReservationList(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(lister.Lister, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.reservation.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(licensing_reservations.ReservationFormatter,
+                       'list_objects')
+    def test_take_action(
+        self,
+        mock_list_objects
+    ):
+        args = mock.Mock()
+        mock_licensing_reservations = mock.Mock()
+        self.mock_app.client_manager.coriolis.licensing_reservations = \
+            mock_licensing_reservations
+
+        result = self.reservation.take_action(args)
+
+        self.assertEqual(
+            mock_list_objects.return_value,
+            result
+        )
+        mock_list_objects.assert_called_once_with(
+            mock_licensing_reservations.list.return_value)
+
+
+class ReservationShowTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Reservation Show."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ReservationShowTestCase, self).setUp()
+        self.reservation = licensing_reservations.ReservationShow(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.reservation.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(licensing_reservations.ReservationFormatter,
+                       'get_formatted_entity')
+    def test_take_action(
+        self,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.appliance_id = mock.sentinel.appliance_id
+        args.reservation_id = mock.sentinel.reservation_id
+        mock_licensing_reservations = mock.Mock()
+        self.mock_app.client_manager.coriolis.licensing_reservations = \
+            mock_licensing_reservations
+
+        result = self.reservation.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_licensing_reservations.show.assert_called_once_with(
+            args.appliance_id, args.reservation_id)
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_licensing_reservations.show.return_value)
+
+
+class ReservationRefreshTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Reservation Refresh."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ReservationRefreshTestCase, self).setUp()
+        self.reservation = licensing_reservations.ReservationRefresh(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.reservation.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(licensing_reservations.ReservationFormatter,
+                       'get_formatted_entity')
+    def test_take_action(
+        self,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        mock_licensing_reservations = mock.Mock()
+        self.mock_app.client_manager.coriolis.licensing_reservations = \
+            mock_licensing_reservations
+
+        result = self.reservation.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_licensing_reservations.refresh.return_value)

--- a/coriolisclient/tests/cli/test_licensing_server.py
+++ b/coriolisclient/tests/cli/test_licensing_server.py
@@ -1,0 +1,96 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from unittest import mock
+
+from cliff import show
+
+from coriolisclient.cli import licensing_server
+from coriolisclient.tests import test_base
+
+
+class ServerStatusFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Server Formatter."""
+
+    def setUp(self):
+        super(ServerStatusFormatterTestCase, self).setUp()
+        self.server = licensing_server.ServerStatusFormatter()
+
+    def test_get_sorted_list(self):
+        obj1 = mock.Mock()
+        obj2 = mock.Mock()
+        obj3 = mock.Mock()
+        obj1.hostname = "host1"
+        obj2.hostname = "host2"
+        obj3.hostname = "host3"
+        obj_list = [obj2, obj1, obj3]
+
+        result = self.server._get_sorted_list(obj_list)
+
+        self.assertEqual(
+            [obj1, obj2, obj3],
+            result
+        )
+
+    def test_get_formatted_data(self):
+        obj = mock.Mock()
+        obj.hostname = mock.sentinel.hostname
+        obj.multi_appliance = mock.sentinel.multi_appliance
+        obj.supported_licence_versions = \
+            mock.sentinel.supported_licence_versions
+        obj.server_local_time = mock.sentinel.server_local_time
+
+        result = self.server._get_formatted_data(obj)
+
+        self.assertEqual(
+            [
+                mock.sentinel.hostname,
+                mock.sentinel.multi_appliance,
+                mock.sentinel.supported_licence_versions,
+                mock.sentinel.server_local_time,
+            ],
+            result
+        )
+
+
+class ServerStatusTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Server Status."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ServerStatusTestCase, self).setUp()
+        self.server = licensing_server.ServerStatus(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.server.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(licensing_server.ServerStatusFormatter,
+                       'get_formatted_entity')
+    def test_take_action(
+        self,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        mock_licensing_server = mock.Mock()
+        self.mock_app.client_manager.coriolis.licensing_server = \
+            mock_licensing_server
+
+        result = self.server.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_licensing_server.status.return_value)

--- a/coriolisclient/tests/cli/test_logging.py
+++ b/coriolisclient/tests/cli/test_logging.py
@@ -1,0 +1,163 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from unittest import mock
+
+from cliff import command
+from cliff import lister
+
+from coriolisclient.cli import logging
+from coriolisclient.tests import test_base
+
+
+class LogsFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Logs Formatter."""
+
+    def setUp(self):
+        super(LogsFormatterTestCase, self).setUp()
+        self.logger = logging.LogsFormatter()
+
+    def test_get_sorted_list(self):
+        obj1 = mock.Mock()
+        obj2 = mock.Mock()
+        obj3 = mock.Mock()
+        obj1.log_name = "log1"
+        obj2.log_name = "log2"
+        obj3.log_name = "log3"
+        obj_list = [obj2, obj1, obj3]
+
+        result = self.logger._get_sorted_list(obj_list)
+
+        self.assertEqual(
+            [obj1, obj2, obj3],
+            result
+        )
+
+    def test_get_formatted_data(self):
+        obj = mock.Mock()
+        obj.log_name = mock.sentinel.log_name
+
+        result = self.logger._get_formatted_data(obj)
+
+        self.assertEqual(
+            (mock.sentinel.log_name,),
+            result
+        )
+
+
+class ListCoriolisLogsTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client List Coriolis Logs."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ListCoriolisLogsTestCase, self).setUp()
+        self.logger = logging.ListCoriolisLogs(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(lister.Lister, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.logger.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(logging.LogsFormatter, 'list_objects')
+    def test_take_action(
+        self,
+        mock_list_objects
+    ):
+        args = mock.Mock()
+        mock_logging = mock.Mock()
+        self.mock_app.client_manager.coriolis.logging.list = mock_logging
+
+        result = self.logger.take_action(args)
+
+        self.assertEqual(
+            mock_list_objects.return_value,
+            result
+        )
+        mock_list_objects.assert_called_once_with(mock_logging.return_value)
+
+
+class DownloadCoriolisLogTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Download Coriolis Log."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(DownloadCoriolisLogTestCase, self).setUp()
+        self.logger = logging.DownloadCoriolisLog(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(command.Command, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.logger.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    def test_take_action(self):
+        args = mock.Mock()
+        args.log_name = mock.sentinel.log_name
+        args.out_file = mock.sentinel.out_file
+        args.start_time = mock.sentinel.start_time
+        args.end_time = mock.sentinel.end_time
+        mock_logging = mock.Mock()
+        self.mock_app.client_manager.coriolis.logging.get = mock_logging
+
+        self.logger.take_action(args)
+
+        mock_logging.assert_called_once_with(
+            mock.sentinel.log_name,
+            mock.sentinel.out_file,
+            start_time=mock.sentinel.start_time,
+            end_time=mock.sentinel.end_time
+        )
+
+
+class StreamCoriolisLogTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Stream Coriolis Log."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(StreamCoriolisLogTestCase, self).setUp()
+        self.logger = logging.StreamCoriolisLog(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(command.Command, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.logger.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    def test_take_action(self):
+        args = mock.Mock()
+        args.log_name = mock.sentinel.log_name
+        args.severity = "INFO"
+        mock_logging = mock.Mock()
+        self.mock_app.client_manager.coriolis.logging.stream = mock_logging
+
+        self.logger.take_action(args)
+
+        mock_logging.assert_called_once_with(
+            app_name=mock.sentinel.log_name,
+            severity=6
+        )

--- a/coriolisclient/tests/cli/test_migrations.py
+++ b/coriolisclient/tests/cli/test_migrations.py
@@ -1,0 +1,568 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+import os
+from unittest import mock
+
+from cliff import command
+from cliff import lister
+from cliff import show
+
+from coriolisclient.cli import formatter
+from coriolisclient.cli import migrations
+from coriolisclient.cli import utils as cli_utils
+from coriolisclient.tests import test_base
+
+
+class MigrationFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Migration Formatter."""
+
+    def setUp(self):
+        super(MigrationFormatterTestCase, self).setUp()
+        self.migration = migrations.MigrationFormatter()
+
+    def test_get_sorted_list(self):
+        obj1 = mock.Mock()
+        obj2 = mock.Mock()
+        obj3 = mock.Mock()
+        obj1.created_at = "date1"
+        obj2.created_at = "date2"
+        obj3.created_at = "date3"
+        obj_list = [obj2, obj1, obj3]
+
+        result = self.migration._get_sorted_list(obj_list)
+
+        self.assertEqual(
+            [obj1, obj2, obj3],
+            result
+        )
+
+    def test_get_formatted_data(self):
+        obj = mock.Mock()
+        obj.id = mock.sentinel.id
+        obj.last_execution_status = mock.sentinel.last_execution_status
+        obj.instances = ["mock_instance3", "mock_instance1", "mock_instance2"]
+        obj.notes = mock.sentinel.notes
+        obj.created_at = mock.sentinel.created_at
+
+        result = self.migration._get_formatted_data(obj)
+
+        self.assertEqual(
+            (
+                mock.sentinel.id,
+                mock.sentinel.last_execution_status,
+                ('mock_instance3%(ls)smock_instance1%(ls)smock_instance2'
+                 % {"ls": os.linesep}),
+                mock.sentinel.notes,
+                mock.sentinel.created_at
+            ),
+            result
+        )
+
+
+class MigrationDetailFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Migration Detail Formatter."""
+
+    def setUp(self):
+        super(MigrationDetailFormatterTestCase, self).setUp()
+        self.migration = migrations.MigrationDetailFormatter(
+            show_instances_data=True)
+
+    def test_format_instances(self):
+        obj = mock.Mock()
+        obj.instances = ["mock_instance3", "mock_instance1", "mock_instance2"]
+        expected_result = (
+            'mock_instance1%(ls)smock_instance2%(ls)smock_instance3'
+            % {"ls": os.linesep}
+        )
+
+        result = self.migration._format_instances(obj)
+
+        self.assertEqual(
+            expected_result,
+            result
+        )
+
+    @mock.patch.object(formatter.EntityFormatter, '_format_progress_update')
+    def test_format_progress_updates(self, mock_format_progress_update):
+        update1 = {"created_at": "date2", "message2": "message2"}
+        update2 = {"created_at": "date3", "message3": "message3"}
+        update3 = {"index": 2, "created_at": "date1"}
+        ret_update1 = "date2 [10] message2"
+        ret_update2 = "date3 [20] message3"
+        ret_update3 = "date1 [30] None"
+        task_dict = {"progress_updates": [update3, update1, update2]}
+        mock_format_progress_update.side_effect = [
+            ret_update1, ret_update2, ret_update3]
+        expected_result = (
+            'date2 [10] message2%(ls)sdate3 [20] message3%(ls)s'
+            'date1 [30] None' % {"ls": os.linesep}
+        )
+
+        result = self.migration._format_progress_updates(task_dict)
+
+        self.assertEqual(
+            expected_result,
+            result
+        )
+
+    @mock.patch.object(migrations.MigrationDetailFormatter,
+                       '_format_progress_updates')
+    def test_format_task(self, mock_format_progress_updates):
+        mock_task = mock.Mock()
+        task = {
+            "depends_on": ["mock_dep1", "mock_dep2"],
+            "id": mock.sentinel.id,
+            "task_type": mock.sentinel.task_type,
+            "instance": mock.sentinel.instance,
+            "status": mock.sentinel.status,
+            "exception_details": mock.sentinel.exception_details
+        }
+        mock_task.to_dict.return_value = task
+        mock_format_progress_updates.return_value = (
+            'date2 [10] message2%(ls)sdate3 [20] message3%(ls)s'
+            'date1 [30] None' % {"ls": os.linesep}
+        )
+        expected_result = (
+            'id: sentinel.id%(ls)s'
+            'task_type: sentinel.task_type%(ls)s'
+            'instance: sentinel.instance%(ls)s'
+            'status: sentinel.status%(ls)s'
+            'depends_on: mock_dep1, mock_dep2%(ls)s'
+            'exception_details: sentinel.exception_details%(ls)s'
+            'progress_updates:%(ls)s'
+            'date2 [10] message2%(ls)s'
+            'date3 [20] message3%(ls)s'
+            'date1 [30] None' % {"ls": os.linesep})
+
+        result = self.migration._format_task(mock_task)
+
+        self.assertEqual(
+            expected_result,
+            result
+        )
+
+    @mock.patch.object(migrations.MigrationDetailFormatter,
+                       '_format_progress_updates')
+    def test_format_task_no_progress_updates(
+        self, mock_format_progress_updates):
+        mock_task = mock.Mock()
+        task = {
+            "depends_on": ["mock_dep1", "mock_dep2"],
+            "id": mock.sentinel.id,
+            "task_type": mock.sentinel.task_type,
+            "instance": mock.sentinel.instance,
+            "status": mock.sentinel.status,
+            "exception_details": mock.sentinel.exception_details
+        }
+        mock_task.to_dict.return_value = task
+        mock_format_progress_updates.return_value = None
+        expected_result = (
+            'id: sentinel.id%(ls)s'
+            'task_type: sentinel.task_type%(ls)s'
+            'instance: sentinel.instance%(ls)s'
+            'status: sentinel.status%(ls)s'
+            'depends_on: mock_dep1, mock_dep2%(ls)s'
+            'exception_details: sentinel.exception_details%(ls)s'
+            'progress_updates:' % {"ls": os.linesep}
+        )
+
+        result = self.migration._format_task(mock_task)
+
+        self.assertEqual(
+            expected_result,
+            result
+        )
+
+    @mock.patch.object(migrations.MigrationDetailFormatter, '_format_task')
+    def test_format_tasks(self, mock_format_task):
+        obj = mock.Mock()
+        obj.tasks = [mock.sentinel.task1, mock.sentinel.task2]
+        mock_format_task.side_effect = ["task1", "task2"]
+        expected_result = 'task1%(ls)s%(ls)stask2' % {"ls": os.linesep}
+
+        result = self.migration._format_tasks(obj)
+
+        self.assertEqual(
+            expected_result,
+            result
+        )
+
+    @mock.patch.object(migrations.MigrationDetailFormatter, '_format_tasks')
+    @mock.patch.object(cli_utils, 'format_mapping')
+    @mock.patch.object(cli_utils, 'format_json_for_object_property')
+    @mock.patch.object(migrations.MigrationDetailFormatter,
+                       '_format_instances')
+    @mock.patch.object(cli_utils, 'parse_storage_mappings')
+    def test_get_formatted_data(
+        self,
+        mock_parse_storage_mappings,
+        mock_format_instances,
+        mock_format_json_for_object_property,
+        mock_format_mapping,
+        mock_format_tasks
+    ):
+        mock_obj = mock.Mock()
+        obj = {
+            "storage_mappings": {'default_storage': mock.sentinel.storage}
+        }
+        mock_obj.to_dict.return_value = obj
+        mock_obj.id = mock.sentinel.id
+        mock_obj.last_execution_status = mock.sentinel.last_execution_status
+        mock_obj.created_at = mock.sentinel.created_at
+        mock_obj.updated_at = mock.sentinel.updated_at
+        mock_obj.reservation_id = mock.sentinel.reservation_id
+        mock_format_instances.return_value = mock.sentinel.formatted_instances
+        mock_obj.notes = mock.sentinel.notes
+        mock_obj.origin_endpoint_id = mock.sentinel.origin_endpoint_id
+        mock_obj.origin_minion_pool_id = mock.sentinel.origin_minion_pool_id
+        mock_obj.destination_endpoint_id = \
+            mock.sentinel.destination_endpoint_id
+        mock_obj.destination_minion_pool_id = \
+            mock.sentinel.destination_minion_pool_id
+        mock_obj.replication_count = mock.sentinel.replication_count
+        mock_obj.shutdown_instances = mock.sentinel.shutdown_instances
+        mock_parse_storage_mappings.return_value = (
+            mock.sentinel.default_storage,
+            mock.sentinel.backend_mappings,
+            mock.sentinel.disk_mappings
+        )
+        mock_format_json_for_object_property.side_effect = [
+            mock.sentinel.instance_osmorphing_minion_pool_mappings,
+            mock.sentinel.destination_environment,
+            mock.sentinel.source_environment,
+            mock.sentinel.network_map,
+            mock.sentinel.user_scripts,
+            mock.sentinel.transfer_result,
+        ]
+        mock_format_mapping.side_effect = [
+            mock.sentinel.disk_mapping, mock.sentinel.backend_mappings]
+        mock_format_tasks.return_value = mock.sentinel.formatted_tasks
+        mock_obj.info = mock.sentinel.info
+        expected_result = [
+            mock.sentinel.id,
+            mock.sentinel.last_execution_status,
+            mock.sentinel.created_at,
+            mock.sentinel.updated_at,
+            mock.sentinel.reservation_id,
+            mock.sentinel.formatted_instances,
+            mock.sentinel.notes,
+            mock.sentinel.origin_endpoint_id,
+            mock.sentinel.origin_minion_pool_id,
+            mock.sentinel.destination_endpoint_id,
+            mock.sentinel.destination_minion_pool_id,
+            mock.sentinel.instance_osmorphing_minion_pool_mappings,
+            mock.sentinel.replication_count,
+            mock.sentinel.shutdown_instances,
+            mock.sentinel.destination_environment,
+            mock.sentinel.source_environment,
+            mock.sentinel.network_map,
+            mock.sentinel.disk_mapping,
+            mock.sentinel.backend_mappings,
+            mock.sentinel.default_storage,
+            mock.sentinel.user_scripts,
+            mock.sentinel.formatted_tasks,
+            mock.sentinel.transfer_result,
+            mock.sentinel.info
+        ]
+
+        result = self.migration._get_formatted_data(mock_obj)
+
+        self.assertEqual(
+            expected_result,
+            result
+        )
+
+
+class CreateMigrationTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Create Migration."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(CreateMigrationTestCase, self).setUp()
+        self.migration = migrations.CreateMigration(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(cli_utils, 'add_args_for_json_option_to_parser')
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+        *_
+    ):
+        result = self.migration.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(cli_utils, 'compose_user_scripts')
+    @mock.patch.object(cli_utils, 'get_storage_mappings_dict_from_args')
+    @mock.patch.object(cli_utils, 'get_option_value_from_args')
+    @mock.patch.object(migrations.MigrationDetailFormatter,
+                       'get_formatted_entity')
+    def test_take_action(
+        self,
+        mock_get_formatted_entity,
+        mock_get_option_value_from_args,
+        mock_get_storage_mappings_dict_from_args,
+        mock_compose_user_scripts
+    ):
+        args = mock.Mock()
+        args.instances = mock.sentinel.instances
+        args.notes = mock.sentinel.notes
+        args.skip_os_morphing = mock.sentinel.skip_os_morphing
+        args.replication_count = mock.sentinel.replication_count
+        args.shutdown_instances = mock.sentinel.shutdown_instances
+        args.origin_minion_pool_id = mock.sentinel.origin_minion_pool_id
+        args.destination_minion_pool_id = \
+            mock.sentinel.destination_minion_pool_id
+        args.instance_osmorphing_minion_pool_mappings = [
+            {'instance_id': "instance_id1", 'pool_id': "pool_id1"},
+            {'instance_id': "instance_id2", 'pool_id': "pool_id2"}
+        ]
+        mock_endpoints = mock.Mock()
+        mock_migrations = mock.Mock()
+        self.mock_app.client_manager.coriolis.endpoints = mock_endpoints
+        mock_endpoints.get_endpoint_id_for_name.side_effect = [
+            mock.sentinel.origin_endpoint_id,
+            mock.sentinel.destination_endpoint_id
+        ]
+        self.mock_app.client_manager.coriolis.migrations.create = \
+            mock_migrations
+        mock_get_option_value_from_args.side_effect = [
+            mock.sentinel.destination_environment,
+            mock.sentinel.source_environment,
+            mock.sentinel.network_map,
+        ]
+
+        result = self.migration.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_migrations.assert_called_once_with(
+            mock.sentinel.origin_endpoint_id,
+            mock.sentinel.destination_endpoint_id,
+            mock.sentinel.source_environment,
+            mock.sentinel.destination_environment,
+            mock.sentinel.instances,
+            network_map=mock.sentinel.network_map,
+            notes=mock.sentinel.notes,
+            storage_mappings=(mock_get_storage_mappings_dict_from_args.
+                              return_value),
+            skip_os_morphing=mock.sentinel.skip_os_morphing,
+            replication_count=mock.sentinel.replication_count,
+            shutdown_instances=mock.sentinel.shutdown_instances,
+            origin_minion_pool_id=mock.sentinel.origin_minion_pool_id,
+            destination_minion_pool_id=
+            mock.sentinel.destination_minion_pool_id,
+            instance_osmorphing_minion_pool_mappings={
+                'instance_id1': 'pool_id1', 'instance_id2': 'pool_id2'},
+            user_scripts=mock_compose_user_scripts.return_value
+        )
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_migrations.return_value)
+
+
+class CreateMigrationFromReplicaTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Create Migration From Replica."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(CreateMigrationFromReplicaTestCase, self).setUp()
+        self.migration = migrations.CreateMigrationFromReplica(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(cli_utils, 'add_args_for_json_option_to_parser')
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+        *_
+    ):
+        result = self.migration.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(cli_utils, 'compose_user_scripts')
+    @mock.patch.object(migrations.MigrationDetailFormatter,
+                       'get_formatted_entity')
+    def test_take_action(
+        self,
+        mock_get_formatted_entity,
+        mock_compose_user_scripts
+    ):
+        args = mock.Mock()
+        args.replica = mock.sentinel.replica
+        args.clone_disks = mock.sentinel.clone_disks
+        args.force = mock.sentinel.force
+        args.skip_os_morphing = mock.sentinel.skip_os_morphing
+        args.instance_osmorphing_minion_pool_mappings = [
+            {'instance_id': "instance_id1", 'pool_id': "pool_id1"},
+            {'instance_id': "instance_id2", 'pool_id': "pool_id2"}
+        ]
+        mock_migrations = mock.Mock()
+        self.mock_app.client_manager.coriolis.migrations = mock_migrations
+
+        result = self.migration.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_migrations.create_from_replica.assert_called_once_with(
+            mock.sentinel.replica,
+            mock.sentinel.clone_disks,
+            mock.sentinel.force,
+            mock.sentinel.skip_os_morphing,
+            user_scripts=mock_compose_user_scripts.return_value,
+            instance_osmorphing_minion_pool_mappings={
+                'instance_id1': 'pool_id1', 'instance_id2': 'pool_id2'}
+        )
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_migrations.create_from_replica.return_value)
+
+
+class ShowMigrationTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Show Migration."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ShowMigrationTestCase, self).setUp()
+        self.migration = migrations.ShowMigration(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(self, mock_get_parser):
+        result = self.migration.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(migrations.MigrationDetailFormatter,
+                       'get_formatted_entity')
+    def test_take_action(self, mock_get_formatted_entity):
+        args = mock.Mock()
+        args.id = mock.sentinel.id
+        mock_migration = mock.Mock()
+        self.mock_app.client_manager.coriolis.migrations.get = mock_migration
+
+        result = self.migration.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_migration.assert_called_once_with(mock.sentinel.id)
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_migration.return_value)
+
+
+class CancelMigrationTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Cancel Migration."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(CancelMigrationTestCase, self).setUp()
+        self.migration = migrations.CancelMigration(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(command.Command, 'get_parser')
+    def test_get_parser(self, mock_get_parser):
+        result = self.migration.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    def test_take_action(self):
+        args = mock.Mock()
+        args.id = mock.sentinel.id
+        args.force = mock.sentinel.force
+        mock_migration = mock.Mock()
+        self.mock_app.client_manager.coriolis.migrations.cancel = \
+            mock_migration
+
+        self.migration.take_action(args)
+
+        mock_migration.assert_called_once_with(
+            mock.sentinel.id, mock.sentinel.force)
+
+
+class DeleteMigrationTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Delete Migration."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(DeleteMigrationTestCase, self).setUp()
+        self.migration = migrations.DeleteMigration(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(command.Command, 'get_parser')
+    def test_get_parser(self, mock_get_parser):
+        result = self.migration.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    def test_take_action(self):
+        args = mock.Mock()
+        args.id = mock.sentinel.id
+        mock_migration = mock.Mock()
+        self.mock_app.client_manager.coriolis.migrations.delete = \
+            mock_migration
+
+        self.migration.take_action(args)
+
+        mock_migration.assert_called_once_with(mock.sentinel.id)
+
+
+class ListMigrationTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client List Migration."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ListMigrationTestCase, self).setUp()
+        self.migration = migrations.ListMigration(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(lister.Lister, 'get_parser')
+    def test_get_parser(self, mock_get_parser):
+        result = self.migration.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(migrations.MigrationFormatter, 'list_objects')
+    def test_take_action(self, mock_list_objects):
+        args = mock.Mock()
+        mock_migration = mock.Mock()
+        self.mock_app.client_manager.coriolis.migrations.list = \
+            mock_migration
+
+        result = self.migration.take_action(args)
+
+        self.assertEqual(
+            mock_list_objects.return_value,
+            result
+        )
+        mock_list_objects.assert_called_once_with(mock_migration.return_value)


### PR DESCRIPTION
This PR adds unit tests for `coriolisclient.cli.*` modules.