### PR TITLE
Cover: Omit unit tests directory

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ setenv =
 commands =
   stestr run --no-subunit-trace {posargs}
   coverage combine
-  coverage report --fail-under=82 --skip-covered
+  coverage report --skip-covered --omit={toxinidir}/coriolisclient/tests/*
   coverage html -d cover
   coverage xml -o cover/coverage.xml
 


### PR DESCRIPTION
This PR fixes inaccurate coverage rate by omitting `coriolisclient/tests` from cover