### PR TITLE
Cover: Add source and omit path

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,12 +21,16 @@ setenv =
 commands =
   stestr run --no-subunit-trace {posargs}
   coverage combine
-  coverage report --skip-covered --omit={toxinidir}/coriolisclient/tests/*
+  coverage report --skip-covered
   coverage html -d cover
   coverage xml -o cover/coverage.xml
 
 [testenv:venv]
 commands = {posargs}
+
+[coverage:run]
+source = coriolisclient
+omit = coriolisclient/tests/*
 
 [flake8]
 # E125 is deliberately excluded. See https://github.com/jcrocholl/pep8/issues/126


### PR DESCRIPTION
This PR adds coverage:run in tox.ini with source and omit paths.