### PR TITLE
Add more unit tests for `coriolisclient.cli.*` modules

### DIFF
--- a/coriolisclient/cli/services.py
+++ b/coriolisclient/cli/services.py
@@ -73,7 +73,7 @@ class CreateService(show.ShowOne):
                             help='The messaging topic for the new service.')
         parser.add_argument('--coriolis-region', action='append',
                             dest='regions', default=[],
-                            help="ID of a region the service should be  "
+                            help="ID of a region the service should be "
                             "associated with. Can be supplied multiple times.")
         _add_service_enablement_args_to_parser(parser)
 
@@ -95,7 +95,7 @@ class UpdateService(show.ShowOne):
         parser.add_argument('id', help='The service\'s ID.')
         parser.add_argument('--coriolis-region', action='append',
                             dest='regions', default=[],
-                            help="ID of a region the service should be  "
+                            help="ID of a region the service should be "
                                  "associated with. Can be supplied multiple "
                                  "times. Update will override all existing "
                                  "region associations with the one(s) provided"

--- a/coriolisclient/tests/cli/test_minion_pools.py
+++ b/coriolisclient/tests/cli/test_minion_pools.py
@@ -1,0 +1,653 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+import os
+from unittest import mock
+
+from cliff import command
+from cliff import lister
+from cliff import show
+
+from coriolisclient.cli import minion_pools
+from coriolisclient.cli import utils as cli_utils
+from coriolisclient.tests import test_base
+
+
+class MinionPoolFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Minion Pool Formatter."""
+
+    def setUp(self):
+        super(MinionPoolFormatterTestCase, self).setUp()
+        self.minion = minion_pools.MinionPoolFormatter()
+
+    def test_get_sorted_list(self):
+        obj1 = mock.Mock()
+        obj2 = mock.Mock()
+        obj3 = mock.Mock()
+        obj1.created_at = "date1"
+        obj2.created_at = "date2"
+        obj3.created_at = "date3"
+        obj_list = [obj2, obj1, obj3]
+
+        result = self.minion._get_sorted_list(obj_list)
+
+        self.assertEqual(
+            [obj1, obj2, obj3],
+            result
+        )
+
+    def test_get_formatted_data(self):
+        obj = mock.Mock()
+        obj.id = mock.sentinel.id
+        obj.name = mock.sentinel.name
+        obj.endpoint_id = mock.sentinel.endpoint_id
+        obj.platform = mock.sentinel.platform
+        obj.os_type = mock.sentinel.os_type
+        obj.notes = mock.sentinel.notes
+        obj.status = mock.sentinel.status
+        obj.minimum_minions = 1
+        obj.maximum_minions = 2
+
+        result = self.minion._get_formatted_data(obj)
+
+        self.assertEqual(
+            (
+                mock.sentinel.id,
+                mock.sentinel.name,
+                mock.sentinel.endpoint_id,
+                mock.sentinel.platform,
+                mock.sentinel.os_type,
+                mock.sentinel.notes,
+                mock.sentinel.status,
+                "1 - 2",
+            ),
+            result
+        )
+
+
+class MinionPoolDetailFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Minion Pool Detail Formatter."""
+
+    def setUp(self):
+        super(MinionPoolDetailFormatterTestCase, self).setUp()
+        self.minion = minion_pools.MinionPoolDetailFormatter()
+
+    def test_get_sorted_list(self):
+        obj1 = mock.Mock()
+        obj2 = mock.Mock()
+        obj3 = mock.Mock()
+        obj1.created_at = "date1"
+        obj2.created_at = "date2"
+        obj3.created_at = "date3"
+        obj_list = [obj2, obj1, obj3]
+
+        result = self.minion._get_sorted_list(obj_list)
+
+        self.assertEqual(
+            [obj1, obj2, obj3],
+            result
+        )
+
+    def test_format_pool_event(self):
+        event = {
+            "level": "mock_level",
+            "created_at": "mock_date",
+            "message": "mock_message",
+        }
+        expected_result = "mock_level mock_date mock_message"
+
+        result = self.minion._format_pool_event(event)
+
+        self.assertEqual(
+            expected_result,
+            result
+        )
+
+    @mock.patch.object(minion_pools.MinionPoolDetailFormatter,
+                       '_format_pool_event')
+    def test_format_pool_events(self, mock_format_pool_event):
+        event1 = {
+            "level": "mock_level1",
+            "created_at": "mock_date1",
+            "message": "mock_message1",
+            "index": 1
+        }
+        event2 = {
+            "level": "mock_level2",
+            "created_at": "mock_date2",
+            "message": "mock_message2",
+            "index": 2
+        }
+        event3 = {
+            "level": "mock_level3",
+            "created_at": "mock_date3",
+            "message": "mock_message3",
+            "index": 3
+        }
+        ret_event1 = "mock_level1 mock_date1 mock_message1"
+        ret_event2 = "mock_level2 mock_date2 mock_message2"
+        ret_event3 = "mock_level3 mock_date3 mock_message3"
+        events = [event3, event1, event2]
+        mock_format_pool_event.side_effect = [
+            ret_event1, ret_event2, ret_event3]
+        expected_result = (
+            "mock_level1 mock_date1 mock_message1%(ls)s"
+            "mock_level2 mock_date2 mock_message2%(ls)s"
+            "mock_level3 mock_date3 mock_message3" % {"ls": os.linesep})
+
+        result = self.minion._format_pool_events(events)
+
+        self.assertEqual(
+            expected_result,
+            result
+        )
+
+    @mock.patch.object(minion_pools.MinionPoolDetailFormatter,
+                       '_format_progress_update')
+    def test__format_progress_updates(self, mock_format_progress_update):
+        update1 = {"created_at": "date2", "message2": "message2"}
+        update2 = {"created_at": "date3", "message3": "message3"}
+        update3 = {"index": 2, "created_at": "date1"}
+        ret_update1 = "date2 [10] message2"
+        ret_update2 = "date3 [20] message3"
+        ret_update3 = "date1 [30] None"
+        progress_updates = [update3, update1, update2]
+        mock_format_progress_update.side_effect = [
+            ret_update1, ret_update2, ret_update3]
+        expected_result = (
+            'date2 [10] message2%(ls)sdate3 [20] message3%(ls)s'
+            'date1 [30] None' % {"ls": os.linesep}
+        )
+
+        result = self.minion._format_progress_updates(progress_updates)
+
+        self.assertEqual(
+            expected_result,
+            result
+        )
+
+    @mock.patch.object(minion_pools.MinionPoolDetailFormatter,
+                       '_format_pool_events')
+    @mock.patch.object(minion_pools.MinionPoolDetailFormatter,
+                       '_format_progress_updates')
+    @mock.patch.object(cli_utils, 'format_json_for_object_property')
+    def test_get_formatted_data(
+        self,
+        mock_format_json_for_object_property,
+        mock_format_progress_updates,
+        mock_format_pool_events
+    ):
+        mock_obj = mock.Mock()
+        mock_obj.id = mock.sentinel.id
+        mock_obj.name = mock.sentinel.name
+        mock_obj.endpoint_id = mock.sentinel.endpoint_id
+        mock_obj.platform = mock.sentinel.platform
+        mock_obj.os_type = mock.sentinel.os_type
+        mock_obj.status = mock.sentinel.status
+        mock_obj.notes = mock.sentinel.notes
+        mock_obj.created_at = mock.sentinel.created_at
+        mock_obj.updated_at = mock.sentinel.updated_at
+        mock_obj.maintenance_trust_id = mock.sentinel.maintenance_trust_id
+        mock_obj.minimum_minions = mock.sentinel.minimum_minions
+        mock_obj.maximum_minions = mock.sentinel.maximum_minions
+        mock_obj.minion_max_idle_time = mock.sentinel.minion_max_idle_time
+        mock_obj.minion_retention_strategy = \
+            mock.sentinel.minion_retention_strategy
+        mock_format_json_for_object_property.side_effect = [
+            mock.sentinel.environment_options,
+            mock.sentinel.shared_resources,
+            mock.sentinel.minion_machines,
+        ]
+        mock_format_pool_events.return_value = \
+            mock.sentinel.formatted_pool_events
+        mock_format_progress_updates.return_value = \
+            mock.sentinel.formatted_progress_updates
+        mock_obj.info = mock.sentinel.info
+        expected_result = (
+            mock.sentinel.id,
+            mock.sentinel.name,
+            mock.sentinel.endpoint_id,
+            mock.sentinel.platform,
+            mock.sentinel.os_type,
+            mock.sentinel.status,
+            mock.sentinel.notes,
+            mock.sentinel.created_at,
+            mock.sentinel.updated_at,
+            mock.sentinel.maintenance_trust_id,
+            mock.sentinel.minimum_minions,
+            mock.sentinel.maximum_minions,
+            mock.sentinel.minion_max_idle_time,
+            mock.sentinel.minion_retention_strategy,
+            mock.sentinel.environment_options,
+            mock.sentinel.shared_resources,
+            mock.sentinel.formatted_pool_events,
+            mock.sentinel.formatted_progress_updates,
+            mock.sentinel.minion_machines,
+        )
+
+        result = self.minion._get_formatted_data(mock_obj)
+
+        self.assertEqual(
+            expected_result,
+            result
+        )
+
+
+class CreateMinionPoolTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Create Minion Pool."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(CreateMinionPoolTestCase, self).setUp()
+        self.minion = minion_pools.CreateMinionPool(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(cli_utils, 'add_args_for_json_option_to_parser')
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+        mock_add_args_for_json_option_to_parser
+    ):
+        result = self.minion.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+        mock_add_args_for_json_option_to_parser.assert_called_once_with(
+            mock_get_parser.return_value, "environment-options")
+
+    @mock.patch.object(minion_pools.MinionPoolDetailFormatter,
+                       'get_formatted_entity')
+    @mock.patch.object(cli_utils, 'get_option_value_from_args')
+    def test_take_action(
+        self,
+        mock_get_option_value_from_args,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.name = mock.sentinel.name
+        args.platform = mock.sentinel.platform
+        args.os_type = mock.sentinel.os_type
+        args.minimum_minions = mock.sentinel.minimum_minions
+        args.maximum_minions = mock.sentinel.maximum_minions
+        args.minion_max_idle_time = mock.sentinel.minion_max_idle_time
+        args.minion_retention_strategy = \
+            mock.sentinel.minion_retention_strategy
+        args.notes = mock.sentinel.notes
+        args.skip_allocation = mock.sentinel.skip_allocation
+        args.endpoint_id = mock.sentinel.endpoint_id
+        mock_endpoints = mock.Mock()
+        mock_endpoints.get_endpoint_id_for_name.return_value = \
+            mock.sentinel.endpoint_id
+        self.mock_app.client_manager.coriolis.endpoints = mock_endpoints
+        mock_minion_pool = mock.Mock()
+        self.mock_app.client_manager.coriolis.minion_pools = \
+            mock_minion_pool
+
+        result = self.minion.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_get_option_value_from_args.assert_called_once_with(
+            args, 'environment-options', error_on_no_value=True)
+        mock_endpoints.get_endpoint_id_for_name.assert_called_once_with(
+            mock.sentinel.endpoint_id)
+        mock_minion_pool.create.assert_called_once_with(
+            mock.sentinel.name,
+            mock.sentinel.endpoint_id,
+            mock.sentinel.platform,
+            mock.sentinel.os_type,
+            mock_get_option_value_from_args.return_value,
+            minimum_minions=mock.sentinel.minimum_minions,
+            maximum_minions=mock.sentinel.maximum_minions,
+            minion_max_idle_time=mock.sentinel.minion_max_idle_time,
+            minion_retention_strategy=mock.sentinel.minion_retention_strategy,
+            notes=mock.sentinel.notes,
+            skip_allocation=mock.sentinel.skip_allocation
+        )
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_minion_pool.create.return_value)
+
+
+class UpdateMinionPoolTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Update Minion Pool."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(UpdateMinionPoolTestCase, self).setUp()
+        self.minion = minion_pools.UpdateMinionPool(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(cli_utils, 'add_args_for_json_option_to_parser')
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+        mock_add_args_for_json_option_to_parser
+    ):
+        result = self.minion.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+        mock_add_args_for_json_option_to_parser.assert_called_once_with(
+            mock_get_parser.return_value, "environment-options")
+
+    @mock.patch.object(minion_pools.MinionPoolDetailFormatter,
+                       'get_formatted_entity')
+    @mock.patch.object(cli_utils, 'get_option_value_from_args')
+    def test_take_action(
+        self,
+        mock_get_option_value_from_args,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.id = mock.sentinel.id
+        args.name = mock.sentinel.name
+        args.os_type = mock.sentinel.os_type
+        args.minimum_minions = mock.sentinel.minimum_minions
+        args.maximum_minions = mock.sentinel.maximum_minions
+        args.minion_max_idle_time = mock.sentinel.minion_max_idle_time
+        args.minion_retention_strategy = \
+            mock.sentinel.minion_retention_strategy
+        args.notes = mock.sentinel.notes
+        args.environment_options = mock.sentinel.environment_options
+        mock_minion_pool = mock.Mock()
+        self.mock_app.client_manager.coriolis.minion_pools = \
+            mock_minion_pool
+        mock_get_option_value_from_args.return_value = \
+            mock.sentinel.environment_options
+        expected_updated_values = {
+            "name": mock.sentinel.name,
+            "os_type": mock.sentinel.os_type,
+            "minimum_minions": mock.sentinel.minimum_minions,
+            "maximum_minions": mock.sentinel.maximum_minions,
+            "minion_max_idle_time": mock.sentinel.minion_max_idle_time,
+            "minion_retention_strategy":
+            mock.sentinel.minion_retention_strategy,
+            "notes": mock.sentinel.notes,
+            "environment_options": mock.sentinel.environment_options
+        }
+
+        result = self.minion.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_get_option_value_from_args.assert_called_once_with(
+            args, 'environment-options', error_on_no_value=False)
+        mock_minion_pool.update.assert_called_once_with(
+            mock.sentinel.id,
+            expected_updated_values
+        )
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_minion_pool.update.return_value)
+
+
+class ShowMinionPoolTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Show Minion Pool."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ShowMinionPoolTestCase, self).setUp()
+        self.minion = minion_pools.ShowMinionPool(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+    ):
+        result = self.minion.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(minion_pools.MinionPoolDetailFormatter,
+                       'get_formatted_entity')
+    def test_take_action(
+        self,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.id = mock.sentinel.id
+        mock_minion_pool = mock.Mock()
+        self.mock_app.client_manager.coriolis.minion_pools = \
+            mock_minion_pool
+
+        result = self.minion.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_minion_pool.get.assert_called_once_with(mock.sentinel.id)
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_minion_pool.get.return_value)
+
+
+class DeleteMinionPoolTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Delete Minion Pool."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(DeleteMinionPoolTestCase, self).setUp()
+        self.minion = minion_pools.DeleteMinionPool(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(command.Command, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+    ):
+        result = self.minion.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    def test_take_action(self):
+        args = mock.Mock()
+        args.id = mock.sentinel.id
+        mock_minion_pool = mock.Mock()
+        self.mock_app.client_manager.coriolis.minion_pools = \
+            mock_minion_pool
+
+        self.minion.take_action(args)
+
+        mock_minion_pool.delete.assert_called_once_with(mock.sentinel.id)
+
+
+class ListMinionPoolsTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis List Minion Pools."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ListMinionPoolsTestCase, self).setUp()
+        self.minion = minion_pools.ListMinionPools(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(lister.Lister, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+    ):
+        result = self.minion.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(minion_pools.MinionPoolFormatter,
+                       'list_objects')
+    def test_take_action(
+        self,
+        mock_list_objects
+    ):
+        args = mock.Mock()
+        mock_minion_pool = mock.Mock()
+        self.mock_app.client_manager.coriolis.minion_pools = \
+            mock_minion_pool
+
+        result = self.minion.take_action(args)
+
+        self.assertEqual(
+            mock_list_objects.return_value,
+            result
+        )
+        mock_list_objects.assert_called_once_with(
+            mock_minion_pool.list.return_value)
+
+
+class AllocateMinionPoolTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Allocate Minion Pool."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(AllocateMinionPoolTestCase, self).setUp()
+        self.minion = minion_pools.AllocateMinionPool(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+    ):
+        result = self.minion.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(minion_pools.MinionPoolDetailFormatter,
+                       'get_formatted_entity')
+    def test_take_action(
+        self,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.id = mock.sentinel.id
+        mock_minion_pool = mock.Mock()
+        self.mock_app.client_manager.coriolis.minion_pools = \
+            mock_minion_pool
+
+        result = self.minion.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_minion_pool.allocate_minion_pool.assert_called_once_with(
+            mock.sentinel.id)
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_minion_pool.allocate_minion_pool.return_value)
+
+
+class RefreshMinionPoolTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Refresh Minion Pool."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(RefreshMinionPoolTestCase, self).setUp()
+        self.minion = minion_pools.RefreshMinionPool(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+    ):
+        result = self.minion.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(minion_pools.MinionPoolDetailFormatter,
+                       'get_formatted_entity')
+    def test_take_action(
+        self,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.id = mock.sentinel.id
+        mock_minion_pool = mock.Mock()
+        self.mock_app.client_manager.coriolis.minion_pools = \
+            mock_minion_pool
+
+        result = self.minion.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_minion_pool.refresh_minion_pool.assert_called_once_with(
+            mock.sentinel.id)
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_minion_pool.refresh_minion_pool.return_value)
+
+
+class DeallocateMinionPoolTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Deallocate Minion Pool."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(DeallocateMinionPoolTestCase, self).setUp()
+        self.minion = minion_pools.DeallocateMinionPool(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+    ):
+        result = self.minion.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(minion_pools.MinionPoolDetailFormatter,
+                       'get_formatted_entity')
+    def test_take_action(
+        self,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.id = mock.sentinel.id
+        args.force = mock.sentinel.force
+        mock_minion_pool = mock.Mock()
+        self.mock_app.client_manager.coriolis.minion_pools = \
+            mock_minion_pool
+
+        result = self.minion.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_minion_pool.deallocate_minion_pool.assert_called_once_with(
+            mock.sentinel.id, force=mock.sentinel.force)
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_minion_pool.deallocate_minion_pool.return_value)

--- a/coriolisclient/tests/cli/test_providers.py
+++ b/coriolisclient/tests/cli/test_providers.py
@@ -1,0 +1,181 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from unittest import mock
+
+from cliff import lister
+
+from coriolisclient.cli import providers
+from coriolisclient.tests import test_base
+
+
+class ProvidersFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Providers Formatter."""
+
+    def setUp(self):
+        super(ProvidersFormatterTestCase, self).setUp()
+        self.provider = providers.ProvidersFormatter()
+
+    def test_get_sorted_list(self):
+        obj1 = {"name": "name1"}
+        obj2 = {"name": "name2"}
+        obj3 = {"name": "name3"}
+        obj_list = [obj2, obj1, obj3]
+
+        result = self.provider._get_sorted_list(obj_list)
+
+        self.assertEqual(
+            [obj1, obj2, obj3],
+            result
+        )
+
+    def test_get_formatted_data(self):
+        obj = {
+            "name": mock.sentinel.name,
+            "types": [1, 2, -1]
+        }
+
+        with self.assertLogs(providers.LOG, level="DEBUG"):
+            result = self.provider._get_formatted_data(obj)
+
+            self.assertEqual(
+                (
+                    mock.sentinel.name,
+                    "%s, %s" % (
+                        providers.PROVIDERS_TYPE_FEATURE_MAP[1],
+                        providers.PROVIDERS_TYPE_FEATURE_MAP[2])
+                ),
+                result
+            )
+
+
+class ProviderSchemasFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Providers Formatter."""
+
+    def setUp(self):
+        super(ProviderSchemasFormatterTestCase, self).setUp()
+        self.provider = providers.ProviderSchemasFormatter()
+
+    def test_get_formatted_data(self):
+        obj = {
+            "type": mock.sentinel.type,
+            "schema": {
+                "connection_info_schema": {"info": "mock_info"},
+                "required": False
+            }
+        }
+
+        result = self.provider._get_formatted_data(obj)
+
+        self.assertEqual(
+            (
+                mock.sentinel.type,
+                ('{\n'
+                 '    "connection_info_schema": {\n'
+                 '        "info": "mock_info"\n'
+                 '    },\n'
+                 '    "required": false\n}')
+            ),
+            result
+        )
+
+
+class ListProviderTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis List Provider."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ListProviderTestCase, self).setUp()
+        self.provider = providers.ListProvider(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(lister.Lister, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+    ):
+        result = self.provider.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(providers.ProvidersFormatter, 'list_objects')
+    def test_take_action(
+        self,
+        mock_list_objects
+    ):
+        args = mock.Mock()
+        mock_provider = mock.Mock()
+        self.mock_app.client_manager.coriolis.providers = mock_provider
+
+        result = self.provider.take_action(args)
+
+        self.assertEqual(
+            mock_list_objects.return_value,
+            result
+        )
+        mock_list_objects.assert_called_once_with(
+            mock_provider.list.return_value.providers_list)
+
+
+class ListProviderSchemasTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis List Provider Schemas."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ListProviderSchemasTestCase, self).setUp()
+        self.provider = providers.ListProviderSchemas(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(lister.Lister, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+    ):
+        result = self.provider.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(providers.ProviderSchemasFormatter, 'list_objects')
+    def test_take_action(
+        self,
+        mock_list_objects
+    ):
+        args = mock.Mock()
+        args.type = "connection"
+        args.platform = mock.sentinel.platform
+        mock_provider = mock.Mock()
+        self.mock_app.client_manager.coriolis.providers = mock_provider
+
+        result = self.provider.take_action(args)
+
+        self.assertEqual(
+            mock_list_objects.return_value,
+            result
+        )
+        mock_provider.schemas_list.assert_called_once_with(
+            mock.sentinel.platform,
+            providers.PROVIDER_SCHEMA_TYPE_MAP["connection"]
+        )
+        mock_obj = mock_provider.schemas_list.return_value.provider_schemas
+        mock_list_objects(mock_obj.providers_list)
+
+    def test_take_action_value_error(self):
+        args = mock.Mock()
+        args.type = "invalid"
+        mock_provider = mock.Mock()
+        self.mock_app.client_manager.coriolis.providers = mock_provider
+
+        self.assertRaises(
+            ValueError,
+            self.provider.take_action,
+            args
+        )
+        mock_provider.schemas_list.assert_not_called()

--- a/coriolisclient/tests/cli/test_regions.py
+++ b/coriolisclient/tests/cli/test_regions.py
@@ -1,0 +1,301 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from unittest import mock
+
+from cliff import command
+from cliff import lister
+from cliff import show
+
+from coriolisclient.cli import regions
+from coriolisclient.tests import test_base
+
+
+class RegionsTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Regions."""
+
+    def test_add_region_enablement_args_to_parser(self):
+            parser = mock.Mock()
+
+            regions._add_region_enablement_args_to_parser(parser)
+
+            parser.add_mutually_exclusive_group.assert_called_once()
+
+
+class RegionFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Regions Formatter."""
+
+    def setUp(self):
+        super(RegionFormatterTestCase, self).setUp()
+        self.region = regions.RegionFormatter()
+
+    def test_get_sorted_list(self):
+        obj1 = mock.Mock()
+        obj2 = mock.Mock()
+        obj3 = mock.Mock()
+        obj1.created_at = "date1"
+        obj2.created_at = "date2"
+        obj3.created_at = "date3"
+        obj_list = [obj2, obj1, obj3]
+
+        result = self.region._get_sorted_list(obj_list)
+
+        self.assertEqual(
+            [obj1, obj2, obj3],
+            result
+        )
+
+    def test_get_formatted_data(self):
+        obj = mock.Mock()
+        obj.id = mock.sentinel.id
+        obj.name = mock.sentinel.name
+        obj.enabled = mock.sentinel.enabled
+        obj.description = mock.sentinel.description
+        obj.mapped_endpoints = mock.sentinel.mapped_endpoints
+        obj.mapped_services = mock.sentinel.mapped_services
+        obj.created_at = mock.sentinel.created_at
+        obj.updated_at = mock.sentinel.updated_at
+
+        result = self.region._get_formatted_data(obj)
+
+        self.assertEqual(
+            (
+                mock.sentinel.id,
+                mock.sentinel.name,
+                mock.sentinel.enabled,
+                mock.sentinel.description,
+                mock.sentinel.mapped_endpoints,
+                mock.sentinel.mapped_services,
+                mock.sentinel.created_at,
+                mock.sentinel.updated_at
+            ),
+            result
+        )
+
+
+class CreateRegionTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Create Region."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(CreateRegionTestCase, self).setUp()
+        self.region = regions.CreateRegion(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(regions, '_add_region_enablement_args_to_parser')
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+        mock_add_region_enablement_args_to_parser
+    ):
+        result = self.region.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+        mock_add_region_enablement_args_to_parser.assert_called_once_with(
+            mock_get_parser.return_value)
+
+    @mock.patch.object(regions.RegionFormatter, 'get_formatted_entity')
+    def test_take_action(
+        self,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.name = mock.sentinel.name
+        args.description = mock.sentinel.description
+        args.enabled = True
+        mock_regions = mock.Mock()
+        self.mock_app.client_manager.coriolis.regions = mock_regions
+
+        result = self.region.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_regions.create.assert_called_once_with(
+            mock.sentinel.name,
+            description=mock.sentinel.description,
+            enabled=True
+        )
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_regions.create.return_value)
+
+
+class UpdateRegionTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Update Region."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(UpdateRegionTestCase, self).setUp()
+        self.region = regions.UpdateRegion(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(regions, '_add_region_enablement_args_to_parser')
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+        mock_add_region_enablement_args_to_parser
+    ):
+        result = self.region.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+        mock_add_region_enablement_args_to_parser.assert_called_once_with(
+            mock_get_parser.return_value)
+
+    @mock.patch.object(regions.RegionFormatter, 'get_formatted_entity')
+    def test_take_action(
+        self,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.id = mock.sentinel.id
+        args.enabled = True
+        args.name = mock.sentinel.name
+        args.description = mock.sentinel.description
+        mock_regions = mock.Mock()
+        self.mock_app.client_manager.coriolis.regions = mock_regions
+        expected_updated_values = {
+            "enabled": True,
+            "name": mock.sentinel.name,
+            "description": mock.sentinel.description,
+        }
+
+        result = self.region.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_regions.update.assert_called_once_with(
+            mock.sentinel.id,
+            expected_updated_values
+        )
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_regions.update.return_value)
+
+
+class ShowRegionTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Show Region."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ShowRegionTestCase, self).setUp()
+        self.region = regions.ShowRegion(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.region.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(regions.RegionFormatter, 'get_formatted_entity')
+    def test_take_action(
+        self,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.id = mock.sentinel.id
+        mock_regions = mock.Mock()
+        self.mock_app.client_manager.coriolis.regions = mock_regions
+
+        result = self.region.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_regions.get.assert_called_once_with(mock.sentinel.id)
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_regions.get.return_value)
+
+
+class DeleteRegionTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Delete Region."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(DeleteRegionTestCase, self).setUp()
+        self.region = regions.DeleteRegion(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(command.Command, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.region.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    def test_take_action(self):
+        args = mock.Mock()
+        args.id = mock.sentinel.id
+        mock_regions = mock.Mock()
+        self.mock_app.client_manager.coriolis.regions = mock_regions
+
+        self.region.take_action(args)
+
+        mock_regions.delete.assert_called_once_with(mock.sentinel.id)
+
+
+class ListRegionsTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis List Regions."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ListRegionsTestCase, self).setUp()
+        self.region = regions.ListRegions(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(lister.Lister, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.region.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(regions.RegionFormatter, 'list_objects')
+    def test_take_action(
+        self,
+        mock_list_objects
+    ):
+        args = mock.Mock()
+        mock_regions = mock.Mock()
+        self.mock_app.client_manager.coriolis.regions = mock_regions
+
+        result = self.region.take_action(args)
+
+        self.assertEqual(
+            mock_list_objects.return_value,
+            result
+        )
+        mock_list_objects.assert_called_once_with(
+            mock_regions.list.return_value)

--- a/coriolisclient/tests/cli/test_replica_executions.py
+++ b/coriolisclient/tests/cli/test_replica_executions.py
@@ -1,0 +1,438 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+import os
+from unittest import mock
+
+from cliff import command
+from cliff import lister
+from cliff import show
+
+from coriolisclient.cli import formatter
+from coriolisclient.cli import replica_executions
+from coriolisclient.tests import test_base
+
+
+class ReplicaExecutionFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Replic Execution Formatter."""
+
+    def setUp(self):
+        super(ReplicaExecutionFormatterTestCase, self).setUp()
+        self.replica = replica_executions.ReplicaExecutionFormatter()
+
+    def test_get_sorted_list(self):
+        obj1 = mock.Mock()
+        obj2 = mock.Mock()
+        obj3 = mock.Mock()
+        obj1.created_at = "date1"
+        obj2.created_at = "date2"
+        obj3.created_at = "date3"
+        obj_list = [obj2, obj1, obj3]
+
+        result = self.replica._get_sorted_list(obj_list)
+
+        self.assertEqual(
+            [obj1, obj2, obj3],
+            result
+        )
+
+    def test_get_formatted_data(self):
+        obj = mock.Mock()
+        obj.action_id = mock.sentinel.action_id
+        obj.id = mock.sentinel.id
+        obj.status = mock.sentinel.status
+        obj.created_at = mock.sentinel.created_at
+
+        result = self.replica._get_formatted_data(obj)
+
+        self.assertEqual(
+            (
+                mock.sentinel.action_id,
+                mock.sentinel.id,
+                mock.sentinel.status,
+                mock.sentinel.created_at
+            ),
+            result
+        )
+
+
+class ReplicaExecutionDetailFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Replica Execution Detail Formatter."""
+
+    def setUp(self):
+        super(ReplicaExecutionDetailFormatterTestCase, self).setUp()
+        self.replica = replica_executions.ReplicaExecutionDetailFormatter()
+
+    def test_format_instances(self):
+        obj = mock.Mock()
+        task1 = mock.Mock()
+        task1.instance = "mock_instance1"
+        task2 = mock.Mock()
+        task2.instance = "mock_instance2"
+        obj.tasks = [task1, task2]
+        expected_result = (
+            'mock_instance1%(ls)smock_instance2'
+            % {"ls": os.linesep}
+        )
+
+        result = self.replica._format_instances(obj)
+
+        self.assertEqual(
+            expected_result,
+            result
+        )
+
+    @mock.patch.object(formatter.EntityFormatter, '_format_progress_update')
+    def test_format_progress_updates(self, mock_format_progress_update):
+        update1 = {"created_at": "date2", "message2": "message2"}
+        update2 = {"created_at": "date3", "message3": "message3"}
+        update3 = {"index": 2, "created_at": "date1"}
+        ret_update1 = "date2 [10] message2"
+        ret_update2 = "date3 [20] message3"
+        ret_update3 = "date1 [30] None"
+        task_dict = {"progress_updates": [update3, update1, update2]}
+        mock_format_progress_update.side_effect = [
+            ret_update1, ret_update2, ret_update3]
+        expected_result = (
+            'date2 [10] message2%(ls)sdate3 [20] message3%(ls)s'
+            'date1 [30] None' % {"ls": os.linesep}
+        )
+
+        result = self.replica._format_progress_updates(task_dict)
+
+        self.assertEqual(
+            expected_result,
+            result
+        )
+
+    @mock.patch.object(replica_executions.ReplicaExecutionDetailFormatter,
+                       '_format_progress_updates')
+    def test_format_task(self, mock_format_progress_updates):
+        mock_task = mock.Mock()
+        task = {
+            "depends_on": ["mock_dep1", "mock_dep2"],
+            "id": mock.sentinel.id,
+            "task_type": mock.sentinel.task_type,
+            "instance": mock.sentinel.instance,
+            "status": mock.sentinel.status,
+            "exception_details": mock.sentinel.exception_details
+        }
+        mock_task.to_dict.return_value = task
+        mock_format_progress_updates.return_value = (
+            'date2 [10] message2%(ls)sdate3 [20] message3%(ls)s'
+            'date1 [30] None' % {"ls": os.linesep}
+        )
+        expected_result = (
+            'id: sentinel.id%(ls)s'
+            'task_type: sentinel.task_type%(ls)s'
+            'instance: sentinel.instance%(ls)s'
+            'status: sentinel.status%(ls)s'
+            'depends_on: mock_dep1, mock_dep2%(ls)s'
+            'exception_details: sentinel.exception_details%(ls)s'
+            'progress_updates:%(ls)s'
+            'date2 [10] message2%(ls)s'
+            'date3 [20] message3%(ls)s'
+            'date1 [30] None' % {"ls": os.linesep})
+
+        result = self.replica._format_task(mock_task)
+
+        self.assertEqual(
+            expected_result,
+            result
+        )
+
+    @mock.patch.object(replica_executions.ReplicaExecutionDetailFormatter,
+                       '_format_progress_updates')
+    def test_format_task_no_progress_updates(
+        self, mock_format_progress_updates):
+        mock_task = mock.Mock()
+        task = {
+            "depends_on": ["mock_dep1", "mock_dep2"],
+            "id": mock.sentinel.id,
+            "task_type": mock.sentinel.task_type,
+            "instance": mock.sentinel.instance,
+            "status": mock.sentinel.status,
+            "exception_details": mock.sentinel.exception_details
+        }
+        mock_task.to_dict.return_value = task
+        mock_format_progress_updates.return_value = None
+        expected_result = (
+            'id: sentinel.id%(ls)s'
+            'task_type: sentinel.task_type%(ls)s'
+            'instance: sentinel.instance%(ls)s'
+            'status: sentinel.status%(ls)s'
+            'depends_on: mock_dep1, mock_dep2%(ls)s'
+            'exception_details: sentinel.exception_details%(ls)s'
+            'progress_updates:' % {"ls": os.linesep}
+        )
+
+        result = self.replica._format_task(mock_task)
+
+        self.assertEqual(
+            expected_result,
+            result
+        )
+
+    @mock.patch.object(replica_executions.ReplicaExecutionDetailFormatter,
+                       '_format_task')
+    def test_format_tasks(self, mock_format_task):
+        obj = mock.Mock()
+        obj.tasks = [mock.sentinel.task1, mock.sentinel.task2]
+        mock_format_task.side_effect = ["task1", "task2"]
+        expected_result = 'task1%(ls)s%(ls)stask2' % {"ls": os.linesep}
+
+        result = self.replica._format_tasks(obj)
+
+        self.assertEqual(
+            expected_result,
+            result
+        )
+
+    @mock.patch.object(replica_executions.ReplicaExecutionDetailFormatter,
+                       '_format_tasks')
+    @mock.patch.object(replica_executions.ReplicaExecutionDetailFormatter,
+                       '_format_instances')
+    def test_get_formatted_data(
+        self,
+        mock_format_instances,
+        mock_format_tasks
+    ):
+        mock_obj = mock.Mock()
+        obj = {
+            "storage_mappings": {'default_storage': mock.sentinel.storage}
+        }
+        mock_obj.to_dict.return_value = obj
+        mock_obj.id = mock.sentinel.id
+        mock_obj.action_id = mock.sentinel.action_id
+        mock_obj.status = mock.sentinel.status
+        mock_obj.created_at = mock.sentinel.created_at
+        mock_obj.updated_at = mock.sentinel.updated_at
+        mock_format_instances.return_value = mock.sentinel.formatted_instances
+        mock_format_tasks.return_value = mock.sentinel.formatted_tasks
+        expected_result = (
+            mock.sentinel.id,
+            mock.sentinel.action_id,
+            mock.sentinel.status,
+            mock.sentinel.created_at,
+            mock.sentinel.updated_at,
+            mock.sentinel.formatted_instances,
+            mock.sentinel.formatted_tasks,
+        )
+
+        result = self.replica._get_formatted_data(mock_obj)
+
+        self.assertEqual(
+            expected_result,
+            result
+        )
+
+
+class CreateReplicaExecutionTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Create Replica Execution."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(CreateReplicaExecutionTestCase, self).setUp()
+        self.replica = replica_executions.CreateReplicaExecution(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.replica.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(replica_executions.ReplicaExecutionDetailFormatter,
+                       'get_formatted_entity')
+    def test_take_action(
+        self,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.replica = mock.sentinel.replica
+        args.shutdown_instances = mock.sentinel.shutdown_instances
+        mock_execution = mock.Mock()
+        self.mock_app.client_manager.coriolis.replica_executions.create = \
+            mock_execution
+
+        result = self.replica.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_execution.assert_called_once_with(
+            mock.sentinel.replica, mock.sentinel.shutdown_instances)
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_execution.return_value)
+
+
+class ShowReplicaExecutionTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Show Replica Execution."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ShowReplicaExecutionTestCase, self).setUp()
+        self.replica = replica_executions.ShowReplicaExecution(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.replica.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(replica_executions.ReplicaExecutionDetailFormatter,
+                       'get_formatted_entity')
+    def test_take_action(
+        self,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.replica = mock.sentinel.replica
+        args.id = mock.sentinel.id
+        execution = mock.Mock()
+        self.mock_app.client_manager.coriolis.replica_executions.get = \
+            execution
+
+        result = self.replica.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        execution.assert_called_once_with(args.replica, args.id)
+        mock_get_formatted_entity.assert_called_once_with(
+            execution.return_value)
+
+
+class CancelReplicaExecutionTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Cancel Replica Execution."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(CancelReplicaExecutionTestCase, self).setUp()
+        self.replica = replica_executions.CancelReplicaExecution(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(command.Command, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.replica.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    def test_take_action(self):
+        args = mock.Mock()
+        args.replica = mock.sentinel.replica
+        args.id = mock.sentinel.id
+        args.force = False
+        replica_execution = mock.Mock()
+        self.mock_app.client_manager.coriolis.replica_executions = \
+            replica_execution
+
+        self.replica.take_action(args)
+
+        replica_execution.cancel.assert_called_once_with(
+            mock.sentinel.replica, mock.sentinel.id, False)
+
+
+class DeleteReplicaExecutionTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Delete Replica Execution."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(DeleteReplicaExecutionTestCase, self).setUp()
+        self.replica = replica_executions.DeleteReplicaExecution(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(command.Command, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.replica.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    def test_take_action(self):
+        args = mock.Mock()
+        args.replica = mock.sentinel.replica
+        args.id = mock.sentinel.id
+        replica_execution = mock.Mock()
+        self.mock_app.client_manager.coriolis.replica_executions = \
+            replica_execution
+
+        self.replica.take_action(args)
+
+        replica_execution.delete.assert_called_once_with(
+            mock.sentinel.replica, mock.sentinel.id)
+
+
+class ListReplicaExecutionTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client List Replica Execution."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ListReplicaExecutionTestCase, self).setUp()
+        self.replica = replica_executions.ListReplicaExecution(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(lister.Lister, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.replica.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(replica_executions.ReplicaExecutionFormatter,
+                       'list_objects')
+    def test_take_action(
+        self,
+        mock_list_objects
+    ):
+        args = mock.Mock()
+        args.replica = mock.sentinel.replica
+        mock_replica_list = mock.Mock()
+        self.mock_app.client_manager.coriolis.replica_executions.list = \
+            mock_replica_list
+
+        result = self.replica.take_action(args)
+
+        self.assertEqual(
+            mock_list_objects.return_value,
+            result
+        )
+        mock_replica_list.assert_called_once_with(mock.sentinel.replica)
+        mock_list_objects.assert_called_once_with(
+            mock_replica_list.return_value)

--- a/coriolisclient/tests/cli/test_replica_schedules.py
+++ b/coriolisclient/tests/cli/test_replica_schedules.py
@@ -1,0 +1,493 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+import argparse
+import datetime
+from unittest import mock
+
+from cliff import command
+from cliff import lister
+from cliff import show
+
+from coriolisclient.cli import replica_schedules
+from coriolisclient import exceptions
+from coriolisclient.tests import test_base
+
+
+class RangeActionTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Replica Range Action."""
+
+    def setUp(self):
+        super(RangeActionTestCase, self).setUp()
+        self.range_action = replica_schedules.RangeAction(
+            1, 10, ["mock_option"], "dest")
+
+    def test__call__(self):
+        mock_parser = mock.Mock()
+        mock_namespace = mock.Mock()
+        value = 5
+
+        self.range_action(mock_parser, mock_namespace, value)
+
+        self.assertEqual(
+            value,
+            mock_namespace.dest
+        )
+
+    def test__call__argument_error(self):
+        mock_parser = mock.Mock()
+        mock_namespace = mock.Mock()
+        value = -1
+
+        self.assertRaises(
+            argparse.ArgumentError,
+            self.range_action,
+            mock_parser,
+            mock_namespace,
+            value
+        )
+
+
+class ReplicaScheduleFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Replica Schedule Formatter."""
+
+    def setUp(self):
+        super(ReplicaScheduleFormatterTestCase, self).setUp()
+        self.replica = replica_schedules.ReplicaScheduleFormatter()
+
+    def test_get_sorted_list(self):
+        obj1 = mock.Mock()
+        obj2 = mock.Mock()
+        obj3 = mock.Mock()
+        obj1.created_at = "date1"
+        obj2.created_at = "date2"
+        obj3.created_at = "date3"
+        obj_list = [obj2, obj1, obj3]
+
+        result = self.replica._get_sorted_list(obj_list)
+
+        self.assertEqual(
+            [obj1, obj2, obj3],
+            result
+        )
+
+    def test_get_formatted_data(self):
+        obj = mock.Mock()
+        obj.replica_id = mock.sentinel.replica_id
+        obj.id = mock.sentinel.id
+        obj.schedule = mock.sentinel.schedule
+        obj.created_at = mock.sentinel.created_at
+        obj.expiration_date = mock.sentinel.expiration_date
+
+        result = self.replica._get_formatted_data(obj)
+
+        self.assertEqual(
+            (
+                mock.sentinel.replica_id,
+                mock.sentinel.id,
+                mock.sentinel.schedule,
+                mock.sentinel.created_at,
+                mock.sentinel.expiration_date
+            ),
+            result
+        )
+
+
+class ReplicaScheduleDetailFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Replica Schedule Detail Formatter."""
+
+    def setUp(self):
+        super(ReplicaScheduleDetailFormatterTestCase, self).setUp()
+        self.replica = replica_schedules.ReplicaScheduleDetailFormatter()
+
+    def test_get_formatted_data(self):
+        obj = mock.Mock()
+        obj.id = mock.sentinel.id
+        obj.replica_id = mock.sentinel.replica_id
+        obj.schedule = mock.sentinel.schedule
+        obj.created_at = mock.sentinel.created_at
+        obj.updated_at = mock.sentinel.updated_at
+        obj.enabled = False
+        obj.expiration_date = mock.sentinel.expiration_date
+        obj.shutdown_instance = mock.sentinel.shutdown_instance
+
+        result = self.replica._get_formatted_data(obj)
+
+        self.assertEqual(
+            (
+                mock.sentinel.id,
+                mock.sentinel.replica_id,
+                mock.sentinel.schedule,
+                mock.sentinel.created_at,
+                mock.sentinel.updated_at,
+                False,
+                mock.sentinel.expiration_date,
+                mock.sentinel.shutdown_instance
+            ),
+            result
+        )
+
+
+class CreateReplicaScheduleTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Create Replica Schedule."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(CreateReplicaScheduleTestCase, self).setUp()
+        self.replica = replica_schedules.CreateReplicaSchedule(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.replica.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(replica_schedules.ReplicaScheduleDetailFormatter,
+                       'get_formatted_entity')
+    @mock.patch.object(replica_schedules, '_parse_expiration_date')
+    @mock.patch.object(replica_schedules, '_parse_schedule_group_args')
+    def test_take_action(
+        self,
+        mock_parse_schedule_group_args,
+        mock_parse_expiration_date,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.replica = mock.sentinel.replica
+        args.disabled = False
+        args.shutdown_instance = mock.sentinel.shutdown_instance
+        mock_schedule_group_args = {"minute": mock.sentinel.minute}
+        mock_parse_schedule_group_args.return_value = mock_schedule_group_args
+        mock_schedule = mock.Mock()
+        self.mock_app.client_manager.coriolis.replica_schedules.create = \
+            mock_schedule
+
+        result = self.replica.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_schedule.assert_called_once_with(
+            mock.sentinel.replica,
+            mock_schedule_group_args,
+            True,
+            mock_parse_expiration_date.return_value,
+            mock.sentinel.shutdown_instance
+        )
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_schedule.return_value)
+
+    @mock.patch.object(replica_schedules, '_parse_expiration_date')
+    @mock.patch.object(replica_schedules, '_parse_schedule_group_args')
+    def test_take_action_no_parsed_schedule(
+        self,
+        mock_parse_schedule_group_args,
+        mock_parse_expiration_date
+    ):
+        args = mock.Mock()
+        mock_parse_schedule_group_args.return_value = {}
+
+        self.assertRaises(
+            exceptions.CoriolisException,
+            self.replica.take_action,
+            args
+        )
+        mock_parse_expiration_date.assert_not_called()
+
+
+class ShowReplicaScheduleTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Show Replica Schedule."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ShowReplicaScheduleTestCase, self).setUp()
+        self.replica = replica_schedules.ShowReplicaSchedule(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.replica.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(replica_schedules.ReplicaScheduleDetailFormatter,
+                       'get_formatted_entity')
+    def test_take_action(
+        self,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.replica = mock.sentinel.replica
+        args.id = mock.sentinel.id
+        schedule = mock.Mock()
+        self.mock_app.client_manager.coriolis.replica_schedules.get = \
+            schedule
+
+        result = self.replica.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        schedule.assert_called_once_with(args.replica, args.id)
+        mock_get_formatted_entity.assert_called_once_with(
+            schedule.return_value)
+
+
+class UpdateReplicaScheduleTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Update Replica Schedule."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(UpdateReplicaScheduleTestCase, self).setUp()
+        self.replica = replica_schedules.UpdateReplicaSchedule(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.replica.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(replica_schedules.ReplicaScheduleDetailFormatter,
+                       'get_formatted_entity')
+    @mock.patch.object(replica_schedules, '_parse_expiration_date')
+    @mock.patch.object(replica_schedules, '_parse_schedule_group_args')
+    def test_take_action(
+        self,
+        mock_parse_schedule_group_args,
+        mock_parse_expiration_date,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.expires = True
+        args.shutdown = True
+        args.enabled = True
+        args.replica = mock.sentinel.replica
+        args.id = mock.sentinel.id
+        mock_parse_schedule_group_args.return_value = \
+            {"minute": mock.sentinel.minute}
+        replica_schedule = mock.Mock()
+        self.mock_app.client_manager.coriolis.replica_schedules = \
+            replica_schedule
+        expected_updated_values = {
+            "schedule": {"minute": mock.sentinel.minute},
+            "expiration_date": mock_parse_expiration_date.return_value,
+            "shutdown_instance": True,
+            "enabled": True,
+        }
+
+        result = self.replica.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+
+        replica_schedule.update.assert_called_once_with(
+            mock.sentinel.replica,
+            mock.sentinel.id,
+            expected_updated_values
+        )
+
+    @mock.patch.object(replica_schedules.ReplicaScheduleDetailFormatter,
+                       'get_formatted_entity')
+    @mock.patch.object(replica_schedules, '_parse_expiration_date')
+    @mock.patch.object(replica_schedules, '_parse_schedule_group_args')
+    def test_take_action_no_updated_values(
+        self,
+        mock_parse_schedule_group_args,
+        mock_parse_expiration_date,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.replica = mock.sentinel.replica
+        args.id = mock.sentinel.id
+        args.expires = False
+        args.shutdown = None
+        args.enabled = None
+        mock_parse_schedule_group_args.return_value = {}
+        replica_schedule = mock.Mock()
+        self.mock_app.client_manager.coriolis.replica_schedules = \
+            replica_schedule
+        expected_updated_values = {"expiration_date": None}
+
+        result = self.replica.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+
+        mock_parse_expiration_date.assert_not_called()
+        replica_schedule.update.assert_called_once_with(
+            mock.sentinel.replica,
+            mock.sentinel.id,
+            expected_updated_values
+        )
+
+
+class DeleteReplicaScheduleTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Delete Replica Schedule."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(DeleteReplicaScheduleTestCase, self).setUp()
+        self.replica = replica_schedules.DeleteReplicaSchedule(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(command.Command, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.replica.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    def test_take_action(self):
+        args = mock.Mock()
+        args.replica = mock.sentinel.replica
+        args.id = mock.sentinel.id
+        replica_schedule = mock.Mock()
+        self.mock_app.client_manager.coriolis.replica_schedules = \
+            replica_schedule
+
+        self.replica.take_action(args)
+
+        replica_schedule.delete.assert_called_once_with(
+            mock.sentinel.replica, mock.sentinel.id)
+
+
+class ListReplicaScheduleTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client List Replica Schedule."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ListReplicaScheduleTestCase, self).setUp()
+        self.replica = replica_schedules.ListReplicaSchedule(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(lister.Lister, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.replica.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(replica_schedules.ReplicaScheduleFormatter,
+                       'list_objects')
+    def test_take_action(
+        self,
+        mock_list_objects
+    ):
+        args = mock.Mock()
+        args.replica = mock.sentinel.replica
+        args.hide_expired = mock.sentinel.hide_expired
+        mock_replica_list = mock.Mock()
+        self.mock_app.client_manager.coriolis.replica_schedules.list = \
+            mock_replica_list
+
+        result = self.replica.take_action(args)
+
+        self.assertEqual(
+            mock_list_objects.return_value,
+            result
+        )
+        mock_replica_list.assert_called_once_with(
+            mock.sentinel.replica, hide_expired=mock.sentinel.hide_expired)
+        mock_list_objects.assert_called_once_with(
+            mock_replica_list.return_value)
+
+
+class ReplicaSchedulesTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Replica Schedules."""
+
+    def test_add_schedule_group(self):
+        parser = argparse.ArgumentParser()
+
+        replica_schedules._add_schedule_group(parser)
+
+        self.assertIn(
+            "Schedule",
+            [g.title for g in parser._action_groups]
+        )
+
+    def test_parse_schedule_group_args(self):
+        class CustomMock(mock.MagicMock):
+            def __getattr__(self, name):
+                return None
+        args = CustomMock()
+        args.minute = mock.sentinel.minute
+        args.hour = mock.sentinel.hour
+        expected_result = {
+            "minute": mock.sentinel.minute,
+            "hour": mock.sentinel.hour
+        }
+
+        result = replica_schedules._parse_schedule_group_args(args)
+
+        self.assertEqual(
+            expected_result,
+            result
+        )
+
+    def test_parse_expiration_date(self):
+        value = None
+
+        result = replica_schedules._parse_expiration_date(value)
+
+        self.assertEqual(
+            None,
+            result
+        )
+
+        value = "2099-12-31"
+
+        result = replica_schedules._parse_expiration_date(value)
+
+        self.assertEqual(
+            datetime.datetime(2099, 12, 31, 0, 0),
+            result
+        )
+
+        value = "2099-31-12"
+
+        self.assertRaises(
+            exceptions.CoriolisException,
+            replica_schedules._parse_expiration_date,
+            value
+        )

--- a/coriolisclient/tests/cli/test_replicas.py
+++ b/coriolisclient/tests/cli/test_replicas.py
@@ -1,0 +1,585 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from unittest import mock
+
+from cliff import command
+from cliff import lister
+from cliff import show
+
+from coriolisclient.cli import replica_executions
+from coriolisclient.cli import replicas
+from coriolisclient.cli import utils as cli_utils
+from coriolisclient.tests import test_base
+
+
+class ReplicaFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Replica Formatter."""
+
+    def setUp(self):
+        super(ReplicaFormatterTestCase, self).setUp()
+        self.replica = replicas.ReplicaFormatter()
+
+    def test_get_sorted_list(self):
+        obj1 = mock.Mock()
+        obj2 = mock.Mock()
+        obj3 = mock.Mock()
+        obj1.created_at = "date1"
+        obj2.created_at = "date2"
+        obj3.created_at = "date3"
+        obj_list = [obj2, obj1, obj3]
+
+        result = self.replica._get_sorted_list(obj_list)
+
+        self.assertEqual(
+            [obj1, obj2, obj3],
+            result
+        )
+
+    def test_format_last_execution(self):
+        obj = mock.Mock()
+        obj.executions = None
+
+        result = self.replica._format_last_execution(obj)
+
+        self.assertEqual(
+            "",
+            result
+        )
+
+        execution1 = mock.Mock()
+        execution2 = mock.Mock()
+        execution3 = mock.Mock()
+        execution1.created_at = "date1"
+        execution2.created_at = "date2"
+        execution3.created_at = "date3"
+        execution1.to_dict.return_value = {
+            "id": "mock_id1",
+            "status": "mock_status1"
+        }
+        execution2.to_dict.return_value = {
+            "id": "mock_id2",
+            "status": "mock_status2"
+        }
+        execution3.to_dict.return_value = {
+            "id": "mock_id3",
+            "status": "mock_status3"
+        }
+        obj.executions = [execution1, execution3, execution2]
+
+        result = self.replica._format_last_execution(obj)
+
+        self.assertEqual(
+            "mock_id3 mock_status3",
+            result
+        )
+
+    def test_get_formatted_data(self):
+        obj = mock.Mock()
+        obj.id = mock.sentinel.id
+        obj.last_execution_status = mock.sentinel.last_execution_status
+        obj.instances = ["mock_instance3", "mock_instance1", "mock_instance2"]
+        obj.notes = mock.sentinel.notes
+        obj.created_at = mock.sentinel.created_at
+
+        result = self.replica._get_formatted_data(obj)
+
+        self.assertEqual(
+            (
+                mock.sentinel.id,
+                ('mock_instance3%(ls)smock_instance1%(ls)smock_instance2'
+                 % {"ls": "\n"}),
+                mock.sentinel.notes,
+                mock.sentinel.last_execution_status,
+                mock.sentinel.created_at
+            ),
+            result
+        )
+
+
+class ReplicaDetailFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Replica Detail Formatter."""
+
+    def setUp(self):
+        super(ReplicaDetailFormatterTestCase, self).setUp()
+        self.replica = replicas.ReplicaDetailFormatter(
+            show_instances_data=True)
+
+    def test_format_instances(self):
+        obj = mock.Mock()
+        obj.instances = ["mock_instance3", "mock_instance1", "mock_instance2"]
+        expected_result = (
+            'mock_instance1%(ls)smock_instance2%(ls)smock_instance3'
+            % {"ls": "\n"}
+        )
+
+        result = self.replica._format_instances(obj)
+
+        self.assertEqual(
+            expected_result,
+            result
+        )
+
+    def test_format_execution(self):
+        execution = mock.Mock()
+        execution.to_dict.return_value = {
+            "id": "mock_id",
+            "status": "mock_status"
+        }
+        expected_result = "mock_id mock_status"
+
+        result = self.replica._format_execution(execution)
+
+        self.assertEqual(
+            expected_result,
+            result
+        )
+
+    @mock.patch.object(replicas.ReplicaDetailFormatter, '_format_execution')
+    def test_format_executions(self, mock_format_execution):
+        executions = mock.Mock()
+        execution1 = mock.Mock()
+        execution2 = mock.Mock()
+        execution3 = mock.Mock()
+        execution1.created_at = "date1"
+        execution2.created_at = "date2"
+        execution3.created_at = "date3"
+        ret_execution1 = "mock_id1 mock_status1"
+        ret_execution2 = "mock_id2 mock_status2"
+        ret_execution3 = "mock_id3 mock_status3"
+        mock_format_execution.side_effect = [
+            ret_execution1, ret_execution2, ret_execution3]
+        executions = [execution1, execution3, execution2]
+        expected_result = (
+            "mock_id1 mock_status1%(ls)s"
+            "mock_id2 mock_status2%(ls)s"
+            "mock_id3 mock_status3" % {"ls": "\n"}
+        )
+
+        result = self.replica._format_executions(executions)
+
+        self.assertEqual(
+            expected_result,
+            result
+        )
+
+    @mock.patch.object(replicas.ReplicaDetailFormatter, '_format_executions')
+    @mock.patch.object(cli_utils, 'format_mapping')
+    @mock.patch.object(cli_utils, 'format_json_for_object_property')
+    @mock.patch.object(replicas.ReplicaDetailFormatter,
+                       '_format_instances')
+    @mock.patch.object(cli_utils, 'parse_storage_mappings')
+    def test_get_formatted_data(
+        self,
+        mock_parse_storage_mappings,
+        mock_format_instances,
+        mock_format_json_for_object_property,
+        mock_format_mapping,
+        mock_format_executions
+    ):
+        mock_obj = mock.Mock()
+        obj = {
+            "storage_mappings": {'default_storage': mock.sentinel.storage}
+        }
+        mock_obj.to_dict.return_value = obj
+        mock_obj.id = mock.sentinel.id
+        mock_obj.created_at = mock.sentinel.created_at
+        mock_obj.updated_at = mock.sentinel.updated_at
+        mock_obj.reservation_id = mock.sentinel.reservation_id
+        mock_format_instances.return_value = mock.sentinel.formatted_instances
+        mock_obj.notes = mock.sentinel.notes
+        mock_obj.origin_endpoint_id = mock.sentinel.origin_endpoint_id
+        mock_obj.origin_minion_pool_id = mock.sentinel.origin_minion_pool_id
+        mock_obj.destination_endpoint_id = \
+            mock.sentinel.destination_endpoint_id
+        mock_obj.destination_minion_pool_id = \
+            mock.sentinel.destination_minion_pool_id
+        mock_parse_storage_mappings.return_value = (
+            mock.sentinel.default_storage,
+            mock.sentinel.backend_mappings,
+            mock.sentinel.disk_mappings
+        )
+        mock_format_json_for_object_property.side_effect = [
+            mock.sentinel.instance_osmorphing_minion_pool_mappings,
+            mock.sentinel.destination_environment,
+            mock.sentinel.source_environment,
+            mock.sentinel.network_map,
+            mock.sentinel.user_scripts
+        ]
+        mock_format_mapping.side_effect = [
+            mock.sentinel.disk_mapping, mock.sentinel.backend_mappings]
+        mock_format_executions.return_value = \
+            mock.sentinel.formatted_executions
+        mock_obj.info = mock.sentinel.info
+        expected_result = [
+            mock.sentinel.id,
+            mock.sentinel.created_at,
+            mock.sentinel.updated_at,
+            mock.sentinel.reservation_id,
+            mock.sentinel.formatted_instances,
+            mock.sentinel.notes,
+            mock.sentinel.origin_endpoint_id,
+            mock.sentinel.origin_minion_pool_id,
+            mock.sentinel.destination_endpoint_id,
+            mock.sentinel.destination_minion_pool_id,
+            mock.sentinel.instance_osmorphing_minion_pool_mappings,
+            mock.sentinel.destination_environment,
+            mock.sentinel.source_environment,
+            mock.sentinel.network_map,
+            mock.sentinel.disk_mapping,
+            mock.sentinel.backend_mappings,
+            mock.sentinel.default_storage,
+            mock.sentinel.user_scripts,
+            mock.sentinel.formatted_executions,
+            mock.sentinel.info
+        ]
+
+        result = self.replica._get_formatted_data(mock_obj)
+
+        self.assertEqual(
+            expected_result,
+            result
+        )
+
+
+class CreateReplicaTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Create Replica."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(CreateReplicaTestCase, self).setUp()
+        self.replica = replicas.CreateReplica(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(cli_utils, 'add_args_for_json_option_to_parser')
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+        *_
+    ):
+        result = self.replica.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(cli_utils, 'compose_user_scripts')
+    @mock.patch.object(cli_utils, 'get_storage_mappings_dict_from_args')
+    @mock.patch.object(cli_utils, 'get_option_value_from_args')
+    @mock.patch.object(replicas.ReplicaDetailFormatter,
+                       'get_formatted_entity')
+    def test_take_action(
+        self,
+        mock_get_formatted_entity,
+        mock_get_option_value_from_args,
+        mock_get_storage_mappings_dict_from_args,
+        mock_compose_user_scripts
+    ):
+        args = mock.Mock()
+        args.instances = mock.sentinel.instances
+        args.notes = mock.sentinel.notes
+        args.origin_minion_pool_id = mock.sentinel.origin_minion_pool_id
+        args.destination_minion_pool_id = \
+            mock.sentinel.destination_minion_pool_id
+        args.instance_osmorphing_minion_pool_mappings = [
+            {'instance_id': "instance_id1", 'pool_id': "pool_id1"},
+            {'instance_id': "instance_id2", 'pool_id': "pool_id2"}
+        ]
+        mock_endpoints = mock.Mock()
+        mock_replicas = mock.Mock()
+        self.mock_app.client_manager.coriolis.endpoints = mock_endpoints
+        mock_endpoints.get_endpoint_id_for_name.side_effect = [
+            mock.sentinel.origin_endpoint_id,
+            mock.sentinel.destination_endpoint_id
+        ]
+        self.mock_app.client_manager.coriolis.replicas.create = \
+            mock_replicas
+        mock_get_option_value_from_args.side_effect = [
+            mock.sentinel.destination_environment,
+            mock.sentinel.source_environment,
+            mock.sentinel.network_map,
+        ]
+
+        result = self.replica.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_replicas.assert_called_once_with(
+            mock.sentinel.origin_endpoint_id,
+            mock.sentinel.destination_endpoint_id,
+            mock.sentinel.source_environment,
+            mock.sentinel.destination_environment,
+            mock.sentinel.instances,
+            network_map=mock.sentinel.network_map,
+            notes=mock.sentinel.notes,
+            storage_mappings=(mock_get_storage_mappings_dict_from_args.
+                              return_value),
+            origin_minion_pool_id=mock.sentinel.origin_minion_pool_id,
+            destination_minion_pool_id=
+            mock.sentinel.destination_minion_pool_id,
+            instance_osmorphing_minion_pool_mappings={
+                'instance_id1': 'pool_id1', 'instance_id2': 'pool_id2'},
+            user_scripts=mock_compose_user_scripts.return_value
+        )
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_replicas.return_value)
+
+
+class ShowReplicaTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Show Replica."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ShowReplicaTestCase, self).setUp()
+        self.replica = replicas.ShowReplica(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(self, mock_get_parser):
+        result = self.replica.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(replicas.ReplicaDetailFormatter,
+                       'get_formatted_entity')
+    def test_take_action(self, mock_get_formatted_entity):
+        args = mock.Mock()
+        args.id = mock.sentinel.id
+        mock_replica = mock.Mock()
+        self.mock_app.client_manager.coriolis.replicas.get = mock_replica
+
+        result = self.replica.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_replica.assert_called_once_with(mock.sentinel.id)
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_replica.return_value)
+
+
+class DeleteReplicaTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Delete Replica."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(DeleteReplicaTestCase, self).setUp()
+        self.replica = replicas.DeleteReplica(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(command.Command, 'get_parser')
+    def test_get_parser(self, mock_get_parser):
+        result = self.replica.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    def test_take_action(self):
+        args = mock.Mock()
+        args.id = mock.sentinel.id
+        mock_replica = mock.Mock()
+        self.mock_app.client_manager.coriolis.replicas.delete = mock_replica
+
+        self.replica.take_action(args)
+
+        mock_replica.assert_called_once_with(mock.sentinel.id)
+
+
+class DeleteReplicaDisksTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Delete Replica Disks."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(DeleteReplicaDisksTestCase, self).setUp()
+        self.replica = replicas.DeleteReplicaDisks(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(command.Command, 'get_parser')
+    def test_get_parser(self, mock_get_parser):
+        result = self.replica.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(replica_executions.ReplicaExecutionDetailFormatter,
+                       'get_formatted_entity')
+    def test_take_action(self, mock_get_formatted_entity):
+        args = mock.Mock()
+        args.id = mock.sentinel.id
+        mock_replica = mock.Mock()
+        self.mock_app.client_manager.coriolis.replicas.delete_disks = \
+            mock_replica
+
+        result = self.replica.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_replica.assert_called_once_with(mock.sentinel.id)
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_replica.return_value)
+
+
+class ListReplicaTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client List Replica."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ListReplicaTestCase, self).setUp()
+        self.replica = replicas.ListReplica(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(lister.Lister, 'get_parser')
+    def test_get_parser(self, mock_get_parser):
+        result = self.replica.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(replicas.ReplicaFormatter, 'list_objects')
+    def test_take_action(self, mock_list_objects):
+        args = mock.Mock()
+        mock_replica = mock.Mock()
+        self.mock_app.client_manager.coriolis.replicas.list = mock_replica
+
+        result = self.replica.take_action(args)
+
+        self.assertEqual(
+            mock_list_objects.return_value,
+            result
+        )
+        mock_list_objects.assert_called_once_with(mock_replica.return_value)
+
+
+class UpdateReplicaTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Client Delete Replica Disks."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(UpdateReplicaTestCase, self).setUp()
+        self.replica = replicas.UpdateReplica(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(self, mock_get_parser):
+        result = self.replica.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(replica_executions.ReplicaExecutionDetailFormatter,
+                       'get_formatted_entity')
+    @mock.patch.object(cli_utils, 'compose_user_scripts')
+    @mock.patch.object(cli_utils, 'get_storage_mappings_dict_from_args')
+    @mock.patch.object(cli_utils, 'get_option_value_from_args')
+    def test_take_action(
+        self,
+        mock_get_option_value_from_args,
+        mock_get_storage_mappings_dict_from_args,
+        mock_compose_user_scripts,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.id = mock.sentinel.id
+        args.global_scripts = mock.sentinel.global_scripts
+        args.instance_scripts = mock.sentinel.instance_scripts
+        args.notes = mock.sentinel.notes
+        args.origin_minion_pool_id = mock.sentinel.origin_minion_pool_id
+        args.destination_minion_pool_id = \
+            mock.sentinel.destination_minion_pool_id
+        args.instance_osmorphing_minion_pool_mappings = [
+            {"instance_id": "mock_instance1", "pool_id": "mock_pool1"},
+            {"instance_id": "mock_instance2", "pool_id": "mock_pool2"}
+        ]
+        mock_replica = mock.Mock()
+        self.mock_app.client_manager.coriolis.replicas = mock_replica
+        mock_get_option_value_from_args.side_effect = [
+            mock.sentinel.destination_environment,
+            mock.sentinel.source_environment,
+            mock.sentinel.network_map
+        ]
+        mock_get_storage_mappings_dict_from_args.return_value = \
+            mock.sentinel.storage_mappings
+        mock_compose_user_scripts.return_value = mock.sentinel.user_scripts
+        expected_updated_properties = {
+            "destination_environment": mock.sentinel.destination_environment,
+            "source_environment": mock.sentinel.source_environment,
+            "storage_mappings": mock.sentinel.storage_mappings,
+            "network_map": mock.sentinel.network_map,
+            "notes": mock.sentinel.notes,
+            "origin_minion_pool_id": mock.sentinel.origin_minion_pool_id,
+            "destination_minion_pool_id":
+            mock.sentinel.destination_minion_pool_id,
+            "instance_osmorphing_minion_pool_mappings":
+            {"mock_instance1": "mock_pool1", "mock_instance2": "mock_pool2"},
+            "user_scripts": mock.sentinel.user_scripts
+        }
+
+        result = self.replica.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_compose_user_scripts.assert_called_once_with(
+            mock.sentinel.global_scripts, mock.sentinel.instance_scripts)
+        mock_replica.update.assert_called_once_with(
+            mock.sentinel.id,
+            expected_updated_properties
+        )
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_replica.update.return_value)
+
+    @mock.patch.object(cli_utils, 'compose_user_scripts')
+    @mock.patch.object(cli_utils, 'get_storage_mappings_dict_from_args')
+    @mock.patch.object(cli_utils, 'get_option_value_from_args')
+    def test_take_action_no_updated_properties(
+        self,
+        mock_get_option_value_from_args,
+        mock_get_storage_mappings_dict_from_args,
+        mock_compose_user_scripts
+    ):
+        class CustomMock(mock.MagicMock):
+            def __getattr__(self, name):
+                return None
+        args = CustomMock()
+        args.global_scripts = mock.sentinel.global_scripts
+        args.instance_scripts = mock.sentinel.instance_scripts
+        mock_replica = mock.Mock()
+        self.mock_app.client_manager.coriolis.replicas = mock_replica
+        mock_get_option_value_from_args.return_value = None
+        mock_get_storage_mappings_dict_from_args.return_value = None
+        mock_compose_user_scripts.return_value = None
+
+        self.assertRaises(
+            ValueError,
+            self.replica.take_action,
+            args
+        )
+
+        mock_compose_user_scripts.assert_called_once_with(
+            mock.sentinel.global_scripts, mock.sentinel.instance_scripts)
+        mock_replica.update.assert_not_called()

--- a/coriolisclient/tests/cli/test_services.py
+++ b/coriolisclient/tests/cli/test_services.py
@@ -1,0 +1,305 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from unittest import mock
+
+from cliff import command
+from cliff import lister
+from cliff import show
+
+from coriolisclient.cli import services
+from coriolisclient.tests import test_base
+
+
+class ServicesTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Services."""
+
+    def test_add_service_enablement_args_to_parser(self):
+            parser = mock.Mock()
+
+            services._add_service_enablement_args_to_parser(parser)
+
+            parser.add_mutually_exclusive_group.assert_called_once()
+
+
+class ServiceFormatterTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Services Formatter."""
+
+    def setUp(self):
+        super(ServiceFormatterTestCase, self).setUp()
+        self.service = services.ServiceFormatter()
+
+    def test_get_sorted_list(self):
+        obj1 = mock.Mock()
+        obj2 = mock.Mock()
+        obj3 = mock.Mock()
+        obj1.created_at = "date1"
+        obj2.created_at = "date2"
+        obj3.created_at = "date3"
+        obj_list = [obj2, obj1, obj3]
+
+        result = self.service._get_sorted_list(obj_list)
+
+        self.assertEqual(
+            [obj1, obj2, obj3],
+            result
+        )
+
+    def test_get_formatted_data(self):
+        obj = mock.Mock()
+        obj.id = mock.sentinel.id
+        obj.host = mock.sentinel.host
+        obj.binary = mock.sentinel.binary
+        obj.topic = mock.sentinel.topic
+        obj.enabled = mock.sentinel.enabled
+        obj.status = mock.sentinel.status
+        obj.mapped_regions = mock.sentinel.mapped_regions
+        obj.created_at = mock.sentinel.created_at
+        obj.updated_at = mock.sentinel.updated_at
+
+        result = self.service._get_formatted_data(obj)
+
+        self.assertEqual(
+            (
+                mock.sentinel.id,
+                mock.sentinel.host,
+                mock.sentinel.binary,
+                mock.sentinel.topic,
+                mock.sentinel.enabled,
+                mock.sentinel.status,
+                mock.sentinel.mapped_regions,
+                mock.sentinel.created_at,
+                mock.sentinel.updated_at
+            ),
+            result
+        )
+
+
+class CreateServiceTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Create Service."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(CreateServiceTestCase, self).setUp()
+        self.service = services.CreateService(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(services, '_add_service_enablement_args_to_parser')
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+        mock_add_service_enablement_args_to_parser
+    ):
+        result = self.service.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+        mock_add_service_enablement_args_to_parser.assert_called_once_with(
+            mock_get_parser.return_value)
+
+    @mock.patch.object(services.ServiceFormatter, 'get_formatted_entity')
+    def test_take_action(
+        self,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.host = mock.sentinel.host
+        args.binary = mock.sentinel.binary
+        args.topic = mock.sentinel.topic
+        args.enabled = True
+        args.regions = mock.sentinel.regions
+        mock_services = mock.Mock()
+        self.mock_app.client_manager.coriolis.services = mock_services
+
+        result = self.service.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_services.create.assert_called_once_with(
+            mock.sentinel.host,
+            mock.sentinel.binary,
+            topic=mock.sentinel.topic,
+            enabled=True,
+            regions=mock.sentinel.regions
+        )
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_services.create.return_value)
+
+
+class UpdateServiceTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Update Service."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(UpdateServiceTestCase, self).setUp()
+        self.service = services.UpdateService(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(services, '_add_service_enablement_args_to_parser')
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser,
+        mock_add_service_enablement_args_to_parser
+    ):
+        result = self.service.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+        mock_add_service_enablement_args_to_parser.assert_called_once_with(
+            mock_get_parser.return_value)
+
+    @mock.patch.object(services.ServiceFormatter, 'get_formatted_entity')
+    def test_take_action(
+        self,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.id = mock.sentinel.id
+        args.enabled = True
+        args.regions = mock.sentinel.regions
+        mock_services = mock.Mock()
+        self.mock_app.client_manager.coriolis.services = mock_services
+        expected_updated_values = {
+            "enabled": True,
+            "mapped_regions": mock.sentinel.regions,
+        }
+
+        result = self.service.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_services.update.assert_called_once_with(
+            mock.sentinel.id,
+            expected_updated_values
+        )
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_services.update.return_value)
+
+
+class ShowServiceTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Show Service."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ShowServiceTestCase, self).setUp()
+        self.service = services.ShowService(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(show.ShowOne, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.service.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(services.ServiceFormatter, 'get_formatted_entity')
+    def test_take_action(
+        self,
+        mock_get_formatted_entity
+    ):
+        args = mock.Mock()
+        args.id = mock.sentinel.id
+        mock_services = mock.Mock()
+        self.mock_app.client_manager.coriolis.services = mock_services
+
+        result = self.service.take_action(args)
+
+        self.assertEqual(
+            mock_get_formatted_entity.return_value,
+            result
+        )
+        mock_services.get.assert_called_once_with(mock.sentinel.id)
+        mock_get_formatted_entity.assert_called_once_with(
+            mock_services.get.return_value)
+
+
+class DeleteServiceTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Delete Service."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(DeleteServiceTestCase, self).setUp()
+        self.service = services.DeleteService(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(command.Command, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.service.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    def test_take_action(self):
+        args = mock.Mock()
+        args.id = mock.sentinel.id
+        mock_services = mock.Mock()
+        self.mock_app.client_manager.coriolis.services = mock_services
+
+        self.service.take_action(args)
+
+        mock_services.delete.assert_called_once_with(mock.sentinel.id)
+
+
+class ListServicesTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis List Services."""
+
+    def setUp(self):
+        self.mock_app = mock.Mock()
+        super(ListServicesTestCase, self).setUp()
+        self.service = services.ListServices(
+            self.mock_app, mock.sentinel.app_args)
+
+    @mock.patch.object(lister.Lister, 'get_parser')
+    def test_get_parser(
+        self,
+        mock_get_parser
+    ):
+        result = self.service.get_parser(mock.sentinel.prog_name)
+
+        self.assertEqual(
+            mock_get_parser.return_value,
+            result
+        )
+        mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
+
+    @mock.patch.object(services.ServiceFormatter, 'list_objects')
+    def test_take_action(
+        self,
+        mock_list_objects
+    ):
+        args = mock.Mock()
+        mock_services = mock.Mock()
+        self.mock_app.client_manager.coriolis.services = mock_services
+
+        result = self.service.take_action(args)
+
+        self.assertEqual(
+            mock_list_objects.return_value,
+            result
+        )
+        mock_list_objects.assert_called_once_with(
+            mock_services.list.return_value)


### PR DESCRIPTION
This PR adds unit tests for `coriolisclient.cli.migrations...services` modules.