### PR TITLE
Add unit tests for `coriolisclient.v1.*` modules

### DIFF
--- a/coriolisclient/tests/v1/test_common.py
+++ b/coriolisclient/tests/v1/test_common.py
@@ -1,0 +1,65 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+import ddt
+
+from coriolisclient import exceptions
+from coriolisclient.tests import test_base
+from coriolisclient.v1 import common
+
+
+class TaskTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis v1 Task."""
+
+    def setUp(self):
+        super(TaskTestCase, self).setUp()
+        self.task = common.Task(
+            None,
+            {
+                "progress_updates": [
+                    {"progress_update1": "mock_update1"},
+                    {"progress_update2": "mock_update2"}
+                ]
+            },
+            loaded=False
+        )
+
+    def test_progress_updates(self):
+        result = self.task.progress_updates
+
+        self.assertEqual(
+            ("mock_update1", "mock_update2"),
+            (result[0].progress_update1, result[1].progress_update2)
+        )
+
+
+@ddt.ddt
+class CommonTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis v1 Common."""
+
+    @ddt.data(
+        ("value", False, "dmFsdWU="),
+        ({"key": "value"}, True, "eyJrZXkiOiAidmFsdWUifQ==")
+    )
+    @ddt.unpack
+    def test_encode_base64_param(self, param, is_json, expected_result):
+        result = common.encode_base64_param(param, is_json=is_json)
+
+        self.assertEqual(
+            result,
+            expected_result
+        )
+
+    @ddt.data(
+        (12345, False),
+        (None, False),
+        ({"key value"}, True)
+    )
+    @ddt.unpack
+    def test_encode_base64_param_raises(self, param, is_json):
+        self.assertRaises(
+            exceptions.CoriolisException,
+            common.encode_base64_param,
+            param,
+            is_json=is_json
+        )

--- a/coriolisclient/tests/v1/test_diagnostics.py
+++ b/coriolisclient/tests/v1/test_diagnostics.py
@@ -1,0 +1,26 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from unittest import mock
+
+from coriolisclient.tests import test_base
+from coriolisclient.v1 import diagnostics
+
+
+class DiagnosticsManagerTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis v1 Diagnostics Manager."""
+
+    def setUp(self):
+        mock_client = mock.Mock()
+        super(DiagnosticsManagerTestCase, self).setUp()
+        self.diag = diagnostics.DiagnosticsManager(mock_client)
+
+    @mock.patch.object(diagnostics.DiagnosticsManager, '_list')
+    def test_get(self, mock_list):
+        result = self.diag.get()
+
+        self.assertEqual(
+            mock_list.return_value,
+            result
+        )
+        mock_list.assert_called_once_with('/diagnostics', 'diagnostics')

--- a/coriolisclient/tests/v1/test_endpoint_destination_minion_pool_options.py
+++ b/coriolisclient/tests/v1/test_endpoint_destination_minion_pool_options.py
@@ -1,0 +1,49 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from unittest import mock
+
+from coriolisclient.tests import test_base
+from coriolisclient.v1 import endpoint_destination_minion_pool_options
+
+
+class EndpointDestinationMinionPoolOptionsManagerTestCase(
+    test_base.CoriolisBaseTestCase):
+    """
+    Test suite for the Coriolis v1 Endpoint Destination Minion Pool Options
+    Manager.
+    """
+
+    def setUp(self):
+        mock_client = mock.Mock()
+        super(EndpointDestinationMinionPoolOptionsManagerTestCase, self
+              ).setUp()
+        self.endpoint = (
+            endpoint_destination_minion_pool_options.
+            EndpointDestinationMinionPoolOptionsManager)(mock_client)
+
+    @mock.patch.object(endpoint_destination_minion_pool_options.
+                       EndpointDestinationMinionPoolOptionsManager, '_list')
+    def test_list(
+        self,
+        mock_list
+    ):
+        mock_endpoint = mock.Mock()
+        mock_endpoint.uuid = '53773ab8-1474-4cf7-bf0c-a496a6595ecb'
+
+        result = self.endpoint.list(
+            mock_endpoint,
+            environment={"env": "mock_env"},
+            option_names=["option1", "option2"]
+        )
+
+        self.assertEqual(
+            mock_list.return_value,
+            result
+        )
+        mock_list.assert_called_once_with(
+            ('/endpoints/53773ab8-1474-4cf7-bf0c-a496a6595ecb/'
+             'destination-minion-pool-options'
+             '?env=eyJlbnYiOiAibW9ja19lbnYifQ=='
+             '&options=WyJvcHRpb24xIiwgIm9wdGlvbjIiXQ=='),
+            'destination_minion_pool_options')

--- a/coriolisclient/tests/v1/test_endpoint_destination_options.py
+++ b/coriolisclient/tests/v1/test_endpoint_destination_options.py
@@ -1,0 +1,45 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from unittest import mock
+
+from coriolisclient.tests import test_base
+from coriolisclient.v1 import endpoint_destination_options
+
+
+class EndpointDestinationOptionsManagerTestCase(
+    test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis v1 Endpoint Destination Options Manager."""
+
+    def setUp(self):
+        mock_client = mock.Mock()
+        super(EndpointDestinationOptionsManagerTestCase, self).setUp()
+        self.endpoint = (
+            endpoint_destination_options.
+            EndpointDestinationOptionsManager)(mock_client)
+
+    @mock.patch.object(endpoint_destination_options.
+                       EndpointDestinationOptionsManager, '_list')
+    def test_list(
+        self,
+        mock_list
+    ):
+        mock_endpoint = mock.Mock()
+        mock_endpoint.uuid = '53773ab8-1474-4cf7-bf0c-a496a6595ecb'
+
+        result = self.endpoint.list(
+            mock_endpoint,
+            environment={"env": "mock_env"},
+            option_names=["option1", "option2"]
+        )
+
+        self.assertEqual(
+            mock_list.return_value,
+            result
+        )
+        mock_list.assert_called_once_with(
+            ('/endpoints/53773ab8-1474-4cf7-bf0c-a496a6595ecb/'
+             'destination-options'
+             '?env=eyJlbnYiOiAibW9ja19lbnYifQ=='
+             '&options=WyJvcHRpb24xIiwgIm9wdGlvbjIiXQ=='),
+            'destination_options')

--- a/coriolisclient/tests/v1/test_endpoint_instances.py
+++ b/coriolisclient/tests/v1/test_endpoint_instances.py
@@ -1,0 +1,115 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from unittest import mock
+
+from coriolisclient.tests import test_base
+from coriolisclient.v1 import common
+from coriolisclient.v1 import endpoint_instances
+
+
+class EndpointInstanceTestCase(
+    test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis v1 Endpoint Instance."""
+
+    def setUp(self):
+        mock_client = mock.Mock()
+        super(EndpointInstanceTestCase, self).setUp()
+        self.endpoint = endpoint_instances.EndpointInstance(
+            mock_client,
+            {"flavor_name": mock.sentinel.flavor_name})
+
+    def test_flavor_name(self):
+        result = self.endpoint.flavor_name
+
+        self.assertEqual(
+            mock.sentinel.flavor_name,
+            result
+        )
+
+
+class EndpointInstanceManagerTestCase(
+    test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis v1 Endpoint Instance Manager."""
+
+    def setUp(self):
+        mock_client = mock.Mock()
+        super(EndpointInstanceManagerTestCase, self).setUp()
+        self.endpoint = endpoint_instances.EndpointInstanceManager(mock_client)
+
+    @mock.patch.object(endpoint_instances.EndpointInstanceManager, '_list')
+    def test_list(
+        self,
+        mock_list
+    ):
+        mock_endpoint = mock.Mock()
+        mock_endpoint.uuid = '53773ab8-1474-4cf7-bf0c-a496a6595ecb'
+
+        result = self.endpoint.list(
+            mock_endpoint,
+            env={"env": "mock_env"},
+            marker="mock_marker",
+            limit="mock_limit",
+            name="mock_name"
+        )
+
+        self.assertEqual(
+            mock_list.return_value,
+            result
+        )
+        mock_list.assert_called_once_with(
+            ('/endpoints/53773ab8-1474-4cf7-bf0c-a496a6595ecb/instances'
+             '?marker=mock_marker&limit=mock_limit&name=mock_name&'
+             'env=eyJlbnYiOiAibW9ja19lbnYifQ%3D%3D'),
+            'instances')
+
+    @mock.patch.object(common, 'encode_base64_param')
+    def test_list_value_error(
+        self,
+        mock_encode_base64_param
+    ):
+        mock_endpoint = mock.Mock()
+        mock_encode_base64_param.return_value = mock.sentinel.encoded_env
+
+        self.assertRaises(
+            ValueError,
+            self.endpoint.list,
+            mock_endpoint,
+            env=mock.sentinel.env
+        )
+
+        mock_encode_base64_param.assert_not_called()
+
+    @mock.patch.object(endpoint_instances.EndpointInstanceManager, '_get')
+    def test_get(
+        self,
+        mock_get
+    ):
+        mock_endpoint = mock.Mock()
+        mock_endpoint.uuid = '53773ab8-1474-4cf7-bf0c-a496a6595ecb'
+
+        result = self.endpoint.get(
+            mock_endpoint,
+            "mock_id",
+            env={"env": "mock_env"},
+        )
+
+        self.assertEqual(
+            mock_get.return_value,
+            result
+        )
+        mock_get.assert_called_once_with(
+            ('/endpoints/53773ab8-1474-4cf7-bf0c-a496a6595ecb/instances/'
+             'bW9ja19pZA==?env=eyJlbnYiOiAibW9ja19lbnYifQ=='),
+            'instance')
+
+    def test_get_value_error(self):
+        mock_endpoint = mock.Mock()
+
+        self.assertRaises(
+            ValueError,
+            self.endpoint.get,
+            mock_endpoint,
+            "mock_instance_id",
+            env=mock.sentinel.env
+        )

--- a/coriolisclient/tests/v1/test_endpoint_networks.py
+++ b/coriolisclient/tests/v1/test_endpoint_networks.py
@@ -1,0 +1,39 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from unittest import mock
+
+from coriolisclient.tests import test_base
+from coriolisclient.v1 import endpoint_networks
+
+
+class EndpointNetworkManagerTestCase(
+    test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis v1 Endpoint Network Manager."""
+
+    def setUp(self):
+        mock_client = mock.Mock()
+        super(EndpointNetworkManagerTestCase, self).setUp()
+        self.endpoint = endpoint_networks.EndpointNetworkManager(mock_client)
+
+    @mock.patch.object(endpoint_networks.EndpointNetworkManager, '_list')
+    def test_list(
+        self,
+        mock_list
+    ):
+        mock_endpoint = mock.Mock()
+        mock_endpoint.uuid = '53773ab8-1474-4cf7-bf0c-a496a6595ecb'
+
+        result = self.endpoint.list(
+            mock_endpoint,
+            environment={"env": "mock_env"},
+        )
+
+        self.assertEqual(
+            mock_list.return_value,
+            result
+        )
+        mock_list.assert_called_once_with(
+            ('/endpoints/53773ab8-1474-4cf7-bf0c-a496a6595ecb/networks'
+             '?env=eyJlbnYiOiAibW9ja19lbnYifQ=='),
+            'networks')

--- a/coriolisclient/tests/v1/test_endpoint_source_minion_pool_options.py
+++ b/coriolisclient/tests/v1/test_endpoint_source_minion_pool_options.py
@@ -1,0 +1,49 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from unittest import mock
+
+from coriolisclient.tests import test_base
+from coriolisclient.v1 import endpoint_source_minion_pool_options
+
+
+class EndpointSourceMinionPoolOptionsManagerTestCase(
+    test_base.CoriolisBaseTestCase):
+    """
+    Test suite for the Coriolis v1 Endpoint Source Minion Pool Options
+    Manager.
+    """
+
+    def setUp(self):
+        mock_client = mock.Mock()
+        super(EndpointSourceMinionPoolOptionsManagerTestCase, self
+              ).setUp()
+        self.endpoint = (
+            endpoint_source_minion_pool_options.
+            EndpointSourceMinionPoolOptionsManager)(mock_client)
+
+    @mock.patch.object(endpoint_source_minion_pool_options.
+                       EndpointSourceMinionPoolOptionsManager, '_list')
+    def test_list(
+        self,
+        mock_list
+    ):
+        mock_endpoint = mock.Mock()
+        mock_endpoint.uuid = '53773ab8-1474-4cf7-bf0c-a496a6595ecb'
+
+        result = self.endpoint.list(
+            mock_endpoint,
+            environment={"env": "mock_env"},
+            option_names=["option1", "option2"]
+        )
+
+        self.assertEqual(
+            mock_list.return_value,
+            result
+        )
+        mock_list.assert_called_once_with(
+            ('/endpoints/53773ab8-1474-4cf7-bf0c-a496a6595ecb/'
+             'source-minion-pool-options'
+             '?env=eyJlbnYiOiAibW9ja19lbnYifQ=='
+             '&options=WyJvcHRpb24xIiwgIm9wdGlvbjIiXQ=='),
+            'source_minion_pool_options')

--- a/coriolisclient/tests/v1/test_endpoint_source_options.py
+++ b/coriolisclient/tests/v1/test_endpoint_source_options.py
@@ -1,0 +1,44 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from unittest import mock
+
+from coriolisclient.tests import test_base
+from coriolisclient.v1 import endpoint_source_options
+
+
+class EndpointSourceOptionsManagerTestCase(
+    test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis v1 Endpoint Source Options Manager."""
+
+    def setUp(self):
+        mock_client = mock.Mock()
+        super(EndpointSourceOptionsManagerTestCase, self).setUp()
+        self.endpoint = (
+            endpoint_source_options.
+            EndpointSourceOptionsManager)(mock_client)
+
+    @mock.patch.object(endpoint_source_options.
+                       EndpointSourceOptionsManager, '_list')
+    def test_list(
+        self,
+        mock_list
+    ):
+        mock_endpoint = mock.Mock()
+        mock_endpoint.uuid = '53773ab8-1474-4cf7-bf0c-a496a6595ecb'
+
+        result = self.endpoint.list(
+            mock_endpoint,
+            environment={"env": "mock_env"},
+            option_names=["option1", "option2"]
+        )
+
+        self.assertEqual(
+            mock_list.return_value,
+            result
+        )
+        mock_list.assert_called_once_with(
+            ('/endpoints/53773ab8-1474-4cf7-bf0c-a496a6595ecb/source-options'
+             '?env=eyJlbnYiOiAibW9ja19lbnYifQ=='
+             '&options=WyJvcHRpb24xIiwgIm9wdGlvbjIiXQ=='),
+            'source_options')

--- a/coriolisclient/tests/v1/test_endpoint_storage.py
+++ b/coriolisclient/tests/v1/test_endpoint_storage.py
@@ -1,0 +1,63 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from unittest import mock
+
+from coriolisclient.tests import test_base
+from coriolisclient.v1 import endpoint_storage
+
+
+class EndpointStorageManagerTestCase(
+    test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis v1 Endpoint Storage Manager."""
+
+    def setUp(self):
+        mock_client = mock.Mock()
+        super(EndpointStorageManagerTestCase, self).setUp()
+        self.endpoint = endpoint_storage.EndpointStorageManager(mock_client)
+
+    @mock.patch.object(endpoint_storage.EndpointStorageManager, '_list')
+    def test_list(
+        self,
+        mock_list
+    ):
+        mock_endpoint = mock.Mock()
+        mock_endpoint.uuid = '53773ab8-1474-4cf7-bf0c-a496a6595ecb'
+
+        result = self.endpoint.list(
+            mock_endpoint,
+            environment={"env": "mock_env"}
+        )
+
+        self.assertEqual(
+            mock_list.return_value,
+            result
+        )
+        mock_list.assert_called_once_with(
+            ('/endpoints/53773ab8-1474-4cf7-bf0c-a496a6595ecb/storage'
+             '?env=eyJlbnYiOiAibW9ja19lbnYifQ=='),
+            'storage',
+            values_key='storage_backends')
+
+    @mock.patch.object(endpoint_storage.EndpointStorageManager, '_get')
+    def test_get_default(
+        self,
+        mock_get
+    ):
+        mock_endpoint = mock.Mock()
+        mock_endpoint.uuid = '53773ab8-1474-4cf7-bf0c-a496a6595ecb'
+        mock_get.return_value = {"config_default": "mock_default"}
+
+        result = self.endpoint.get_default(
+            mock_endpoint,
+            environment={"env": "mock_env"},
+        )
+
+        self.assertEqual(
+            "mock_default",
+            result
+        )
+        mock_get.assert_called_once_with(
+            ('/endpoints/53773ab8-1474-4cf7-bf0c-a496a6595ecb/storage'
+             '?env=eyJlbnYiOiAibW9ja19lbnYifQ=='),
+            'storage')

--- a/coriolisclient/tests/v1/test_endpoints.py
+++ b/coriolisclient/tests/v1/test_endpoints.py
@@ -1,0 +1,262 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from unittest import mock
+
+from coriolisclient import exceptions
+from coriolisclient.tests import test_base
+from coriolisclient.v1 import endpoints
+
+
+class EndpointTestCase(
+    test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis v1 Endpoint."""
+
+    def setUp(self):
+        super(EndpointTestCase, self).setUp()
+        self.endpoint = endpoints.Endpoint(
+            None,
+            {
+                "connection_info": {
+                    "connection_info1": mock.sentinel.connection_info}
+            }
+        )
+
+    def test_connection_info(self):
+        result = self.endpoint.connection_info
+
+        self.assertEqual(
+            mock.sentinel.connection_info,
+            result.connection_info1
+        )
+
+
+class EndpointManagerTestCase(
+    test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis v1 Endpoint Manager."""
+
+    def setUp(self):
+        self.mock_client = mock.Mock()
+        super(EndpointManagerTestCase, self).setUp()
+        self.endpoint = endpoints.EndpointManager(self.mock_client)
+
+    @mock.patch.object(endpoints.EndpointManager, '_list')
+    def test_list(
+        self,
+        mock_list
+    ):
+        result = self.endpoint.list()
+
+        self.assertEqual(
+            mock_list.return_value,
+            result
+        )
+        mock_list.assert_called_once_with('/endpoints', 'endpoints')
+
+    @mock.patch.object(endpoints.EndpointManager, '_get')
+    def test_get(
+        self,
+        mock_get
+    ):
+        mock_endpoint = mock.Mock()
+        mock_endpoint.uuid = '53773ab8-1474-4cf7-bf0c-a496a6595ecb'
+
+        result = self.endpoint.get(mock_endpoint)
+
+        self.assertEqual(
+            mock_get.return_value,
+            result
+        )
+        mock_get.assert_called_once_with(
+            '/endpoints/53773ab8-1474-4cf7-bf0c-a496a6595ecb', 'endpoint')
+
+    @mock.patch.object(endpoints.EndpointManager, '_post')
+    def test_create(
+        self,
+        mock_post
+    ):
+        result = self.endpoint.create(
+            mock.sentinel.name,
+            mock.sentinel.endpoint_type,
+            mock.sentinel.connection_info,
+            mock.sentinel.description,
+            mock.sentinel.regions
+        )
+        expected_data = {
+            "endpoint": {
+                "name": mock.sentinel.name,
+                "type": mock.sentinel.endpoint_type,
+                "description": mock.sentinel.description,
+                "connection_info": mock.sentinel.connection_info,
+                "mapped_regions": mock.sentinel.regions
+            }
+        }
+
+        self.assertEqual(
+            mock_post.return_value,
+            result
+        )
+        mock_post.assert_called_once_with(
+            '/endpoints', expected_data, 'endpoint')
+
+    @mock.patch.object(endpoints.EndpointManager, '_put')
+    def test_update(
+        self,
+        mock_put
+    ):
+        mock_endpoint = mock.Mock()
+        mock_endpoint.uuid = '53773ab8-1474-4cf7-bf0c-a496a6595ecb'
+
+        result = self.endpoint.update(
+            mock_endpoint,
+            mock.sentinel.updated_values
+        )
+        expected_data = {
+            "endpoint": mock.sentinel.updated_values
+        }
+
+        self.assertEqual(
+            mock_put.return_value,
+            result
+        )
+        mock_put.assert_called_once_with(
+            '/endpoints/53773ab8-1474-4cf7-bf0c-a496a6595ecb',
+            expected_data, 'endpoint')
+
+    @mock.patch.object(endpoints.EndpointManager, '_delete')
+    def test_delete(
+        self,
+        mock_delete
+    ):
+        mock_endpoint = mock.Mock()
+        mock_endpoint.uuid = '53773ab8-1474-4cf7-bf0c-a496a6595ecb'
+
+        result = self.endpoint.delete(mock_endpoint)
+
+        self.assertEqual(
+            mock_delete.return_value,
+            result
+        )
+        mock_delete.assert_called_once_with(
+            '/endpoints/53773ab8-1474-4cf7-bf0c-a496a6595ecb')
+
+    def test_validate_connection(self):
+        mock_endpoint = mock.Mock()
+        mock_endpoint.uuid = '53773ab8-1474-4cf7-bf0c-a496a6595ecb'
+        self.mock_client.post.return_value.json.return_value = {
+            "validate-connection": {
+                "valid": mock.sentinel.valid,
+                "message": mock.sentinel.message
+            }
+        }
+
+        result = self.endpoint.validate_connection(mock_endpoint)
+
+        self.assertEqual(
+            (mock.sentinel.valid, mock.sentinel.message),
+            result
+        )
+        self.mock_client.post.assert_called_once_with(
+            '/endpoints/53773ab8-1474-4cf7-bf0c-a496a6595ecb/actions',
+            json={'validate-connection': None})
+
+    @mock.patch.object(endpoints.EndpointManager, '_get_endpoint_id_for_name')
+    def test_get_endpoint_id_for_name_uuid(
+        self,
+        mock_get_endpoint_id_for_name
+    ):
+        mock_endpoint = '53773ab8-1474-4cf7-bf0c-a496a6595ecb'
+        result = self.endpoint.get_endpoint_id_for_name(mock_endpoint)
+
+        self.assertEqual(
+            '53773ab8-1474-4cf7-bf0c-a496a6595ecb',
+            result
+        )
+        mock_get_endpoint_id_for_name.assert_not_called()
+
+    @mock.patch.object(endpoints.EndpointManager, '_get_endpoint_id_for_name')
+    def test_get_endpoint_id_for_name(
+        self,
+        mock_get_endpoint_id_for_name
+    ):
+        mock_endpoint = mock.Mock()
+
+        result = self.endpoint.get_endpoint_id_for_name(mock_endpoint)
+
+        self.assertEqual(
+            mock_get_endpoint_id_for_name.return_value,
+            result
+        )
+
+    @mock.patch.object(endpoints.EndpointManager, 'list')
+    def test__get_endpoint_id_for_name(
+        self,
+        mock_list
+    ):
+        obj1 = mock.Mock()
+        obj2 = mock.Mock()
+        obj3 = mock.Mock()
+        obj1.id = '1'
+        obj2.id = '2'
+        obj3.id = '3'
+        obj1.name = 'mock_name1'
+        obj2.name = 'mock_name2'
+        obj3.name = 'mock_name3'
+        obj_list = [obj1, obj2, obj3]
+        mock_list.return_value = obj_list
+        endpoint_name = "mock_name2"
+
+        result = self.endpoint._get_endpoint_id_for_name(endpoint_name)
+
+        self.assertEqual(
+            '2',
+            result
+        )
+
+    @mock.patch.object(endpoints.EndpointManager, 'list')
+    def test__get_endpoint_id_for_name_not_found(
+        self,
+        mock_list
+    ):
+        obj1 = mock.Mock()
+        obj2 = mock.Mock()
+        obj3 = mock.Mock()
+        obj1.id = '1'
+        obj2.id = '2'
+        obj3.id = '3'
+        obj1.name = 'mock_name1'
+        obj2.name = 'mock_name2'
+        obj3.name = 'mock_name3'
+        obj_list = [obj1, obj2, obj3]
+        mock_list.return_value = obj_list
+        endpoint_name = "mock_name4"
+
+        self.assertRaises(
+            exceptions.EndpointIDNotFound,
+            self.endpoint._get_endpoint_id_for_name,
+            endpoint_name
+        )
+
+    @mock.patch.object(endpoints.EndpointManager, 'list')
+    def test__get_endpoint_id_for_name_not_unique(
+        self,
+        mock_list
+    ):
+        obj1 = mock.Mock()
+        obj2 = mock.Mock()
+        obj3 = mock.Mock()
+        obj1.id = '1'
+        obj2.id = '2'
+        obj3.id = '3'
+        obj1.name = 'mock_name1'
+        obj2.name = 'mock_name2'
+        obj3.name = 'mock_name2'
+        obj_list = [obj1, obj2, obj3]
+        mock_list.return_value = obj_list
+        endpoint_name = "mock_name2"
+
+        self.assertRaises(
+            exceptions.NoUniqueEndpointNameMatch,
+            self.endpoint._get_endpoint_id_for_name,
+            endpoint_name
+        )


### PR DESCRIPTION
This PR adds unit tests for `coriolisclient.v1.common...endpoints` modules.