### PR TITLE
tests: Adds mock patch autospec fixture

### DIFF
--- a/coriolisclient/tests/cli/test_diagnostics.py
+++ b/coriolisclient/tests/cli/test_diagnostics.py
@@ -60,7 +60,8 @@ class GetCoriolisDiagnosticsTestCase(test_base.CoriolisBaseTestCase):
     def setUp(self, mock__init__):
         mock__init__.return_value = None
         super(GetCoriolisDiagnosticsTestCase, self).setUp()
-        self.diag = diagnostics.GetCoriolisDiagnostics()
+        self.diag = diagnostics.GetCoriolisDiagnostics(
+            mock.sentinel.app, mock.sentinel.app_args)
 
     @mock.patch.object(lister.Lister, 'get_parser')
     def test_get_parser(self, mock_get_parser):

--- a/coriolisclient/tests/test_base.py
+++ b/coriolisclient/tests/test_base.py
@@ -4,6 +4,13 @@
 """Defines base class for all tests."""
 
 from oslotest import base
+from oslotest import mock_fixture
+
+# NOTE(claudiub): this needs to be called before any mock.patch calls are
+# being done, and especially before any other test classes load. This fixes
+# the mock.patch autospec issue:
+# https://github.com/testing-cabal/mock/issues/396
+mock_fixture.patch_mock_module()
 
 
 class CoriolisBaseTestCase(base.BaseTestCase):


### PR DESCRIPTION
When mocking something, there's the possibility to reference a property that does not exist, or call a method with invalid arguments, but the unit tests to keep passing, resulting in false positives.

We've seen this issue several times in OpenStack, and we have created and started using a mock patch fixture (can be seen in OpenStack Nova's ``test.py``) which enables autospec by default.

This guarantees 2 things: that the thing we're patching exists, and if it's callable, that the calls respect the callable's signature (e.g.: no unknown arguments can be used).