### PR TITLE
Fix getting the endpoint storage default

### DIFF
--- a/coriolisclient/tests/v1/test_endpoint_storage.py
+++ b/coriolisclient/tests/v1/test_endpoint_storage.py
@@ -46,7 +46,8 @@ class EndpointStorageManagerTestCase(
     ):
         mock_endpoint = mock.Mock()
         mock_endpoint.uuid = '53773ab8-1474-4cf7-bf0c-a496a6595ecb'
-        mock_get.return_value = {"config_default": "mock_default"}
+        mock_get.return_value = endpoint_storage.EndpointStorage(
+            mock.Mock(), {"config_default": "mock_default"})
 
         result = self.endpoint.get_default(
             mock_endpoint,

--- a/coriolisclient/v1/endpoint_storage.py
+++ b/coriolisclient/v1/endpoint_storage.py
@@ -43,4 +43,4 @@ class EndpointStorageManager(base.BaseManager):
             encoded_env = common.encode_base64_param(environment, is_json=True)
             url = '%s?env=%s' % (url, encoded_env)
 
-        return self._get(url, 'storage').get('config_default')
+        return self._get(url, 'storage').to_dict().get('config_default')


### PR DESCRIPTION
Currently, trying to get the endpoint storage default ends with the following error:

```
Traceback (most recent call last):
  File "/home/ubuntu/workdir/python-coriolisclient/v1/endpoint_storage.py", line 48, in get_default
TypeError: Resource.get() takes 1 positional argument but 2 were given
```