### PR TITLE
Allow using pagination

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
         architecture: ["x64"]
 
     steps:

--- a/coriolisclient/base.py
+++ b/coriolisclient/base.py
@@ -22,6 +22,7 @@ import logging
 import traceback
 
 import six
+from six.moves.urllib import parse as urlparse
 
 from keystoneauth1 import exceptions as keystoneauth_exceptions
 from oslo_utils import strutils
@@ -166,7 +167,7 @@ class BaseManager(object):
 
     @wrap_unauthorized_exception
     def _list(self, url, response_key=None, obj_class=None, json=None,
-              values_key='values'):
+              values_key='values', query: dict | None=None):
         """List the collection.
         :param url: a partial URL, e.g., '/servers'
         :param response_key: the key to be looked up in response dictionary,
@@ -176,7 +177,12 @@ class BaseManager(object):
             (self.resource_class will be used by default)
         :param json: data that will be encoded as JSON and passed in POST
             request (GET will be sent by default)
+        :param query: an optional dict containing query filters
         """
+
+        if query:
+            url += "?" + urlparse.urlencode(query)
+
         if json:
             body = self.client.post(url, json=json).json()
         else:

--- a/coriolisclient/base.py
+++ b/coriolisclient/base.py
@@ -167,7 +167,7 @@ class BaseManager(object):
 
     @wrap_unauthorized_exception
     def _list(self, url, response_key=None, obj_class=None, json=None,
-              values_key='values', query: dict | None=None):
+              values_key='values', query: dict | list | None=None):
         """List the collection.
         :param url: a partial URL, e.g., '/servers'
         :param response_key: the key to be looked up in response dictionary,
@@ -177,7 +177,8 @@ class BaseManager(object):
             (self.resource_class will be used by default)
         :param json: data that will be encoded as JSON and passed in POST
             request (GET will be sent by default)
-        :param query: an optional dict containing query filters
+        :param query: an optional dict or list of (key, value) tuples
+            containing query filters
         """
 
         if query:

--- a/coriolisclient/base.py
+++ b/coriolisclient/base.py
@@ -167,7 +167,7 @@ class BaseManager(object):
 
     @wrap_unauthorized_exception
     def _list(self, url, response_key=None, obj_class=None, json=None,
-              values_key='values', query: dict | list | None=None):
+              values_key='values', query: dict | list | None = None):
         """List the collection.
         :param url: a partial URL, e.g., '/servers'
         :param response_key: the key to be looked up in response dictionary,

--- a/coriolisclient/cli/deployments.py
+++ b/coriolisclient/cli/deployments.py
@@ -287,9 +287,11 @@ class ListDeployment(lister.Lister):
         return parser
 
     def take_action(self, args):
+        sort_keys, sort_dirs = cli_utils.parse_sort_arg(args.sort)
         obj_list = self.app.client_manager.coriolis.deployments.list(
             marker=args.marker,
             limit=args.limit,
-            sort_keys=args.sort_keys,
-            sort_dirs=args.sort_dirs)
+            sort_keys=sort_keys,
+            sort_dirs=sort_dirs,
+        )
         return DeploymentFormatter().list_objects(obj_list)

--- a/coriolisclient/cli/deployments.py
+++ b/coriolisclient/cli/deployments.py
@@ -281,15 +281,15 @@ class ListDeployment(lister.Lister):
             help='Maximum number of executions to retrieve.')
         parser.add_argument(
             '--sort',
-            help='Comma-separated list of sort keys and directions in the form '
-           'of <key>[:<asc|desc>]. The direction defaults to descending if '
-           'not specified.')
+            help='Comma-separated list of sort keys and directions in the '
+                 'form of <key>[:<asc|desc>]. The direction defaults to '
+                 'descending if not specified.')
         return parser
 
     def take_action(self, args):
         obj_list = self.app.client_manager.coriolis.deployments.list(
             marker=args.marker,
             limit=args.limit,
-            sort_keys=sort_keys,
-            sort_dirs=sort_dirs)
+            sort_keys=args.sort_keys,
+            sort_dirs=args.sort_dirs)
         return DeploymentFormatter().list_objects(obj_list)

--- a/coriolisclient/cli/deployments.py
+++ b/coriolisclient/cli/deployments.py
@@ -273,8 +273,23 @@ class ListDeployment(lister.Lister):
 
     def get_parser(self, prog_name):
         parser = super(ListDeployment, self).get_parser(prog_name)
+        parser.add_argument(
+            '--marker',
+            help='The id of the last retrieved execution.')
+        parser.add_argument(
+            '--limit', type=int,
+            help='Maximum number of executions to retrieve.')
+        parser.add_argument(
+            '--sort',
+            help='Comma-separated list of sort keys and directions in the form '
+           'of <key>[:<asc|desc>]. The direction defaults to descending if '
+           'not specified.')
         return parser
 
     def take_action(self, args):
-        obj_list = self.app.client_manager.coriolis.deployments.list()
+        obj_list = self.app.client_manager.coriolis.deployments.list(
+            marker=args.marker,
+            limit=args.limit,
+            sort_keys=sort_keys,
+            sort_dirs=sort_dirs)
         return DeploymentFormatter().list_objects(obj_list)

--- a/coriolisclient/cli/deployments.py
+++ b/coriolisclient/cli/deployments.py
@@ -275,10 +275,10 @@ class ListDeployment(lister.Lister):
         parser = super(ListDeployment, self).get_parser(prog_name)
         parser.add_argument(
             '--marker',
-            help='The id of the last retrieved execution.')
+            help='The id of the last retrieved deployment.')
         parser.add_argument(
             '--limit', type=int,
-            help='Maximum number of executions to retrieve.')
+            help='Maximum number of deployments to retrieve.')
         parser.add_argument(
             '--sort',
             help='Comma-separated list of sort keys and directions in the '

--- a/coriolisclient/cli/transfer_executions.py
+++ b/coriolisclient/cli/transfer_executions.py
@@ -195,11 +195,11 @@ class ListTransferExecution(lister.Lister):
         return parser
 
     def take_action(self, args):
-        sort_keys, sort_dirs = cli_utils.parse_sort_args(args.sort)
+        sort_keys, sort_dirs = cli_utils.parse_sort_arg(args.sort)
         obj_list = self.app.client_manager.coriolis.transfer_executions.list(
             args.transfer,
             marker=args.marker,
             limit=args.limit,
-            sort_keys=args.sort_keys,
-            sort_dirs=args.sort_dirs)
+            sort_keys=sort_keys,
+            sort_dirs=sort_dirs)
         return TransferExecutionFormatter().list_objects(obj_list)

--- a/coriolisclient/cli/transfer_executions.py
+++ b/coriolisclient/cli/transfer_executions.py
@@ -22,6 +22,7 @@ from cliff import lister
 from cliff import show
 
 from coriolisclient.cli import formatter
+from coriolisclient.cli import utils as cli_utils
 
 
 class TransferExecutionFormatter(formatter.EntityFormatter):
@@ -186,9 +187,19 @@ class ListTransferExecution(lister.Lister):
         parser.add_argument(
             '--limit', type=int,
             help='Maximum number of executions to retrieve.')
+        parser.add_argument(
+            '--sort',
+            help='Comma-separated list of sort keys and directions in the form '
+           'of <key>[:<asc|desc>]. The direction defaults to descending if '
+           'not specified.')
         return parser
 
     def take_action(self, args):
+        sort_keys, sort_dirs = cli_utils.parse_sort_args(arg.sort)
         obj_list = self.app.client_manager.coriolis.transfer_executions.list(
-            args.transfer)
+            args.transfer,
+            marker=args.marker,
+            limit=args.limit,
+            sort_keys=sort_keys,
+            sort_dirs=sort_dirs)
         return TransferExecutionFormatter().list_objects(obj_list)

--- a/coriolisclient/cli/transfer_executions.py
+++ b/coriolisclient/cli/transfer_executions.py
@@ -180,6 +180,12 @@ class ListTransferExecution(lister.Lister):
     def get_parser(self, prog_name):
         parser = super(ListTransferExecution, self).get_parser(prog_name)
         parser.add_argument('transfer', help='The transfer\'s id')
+        parser.add_argument(
+            '--marker',
+            help='The id of the last retrieved execution.')
+        parser.add_argument(
+            '--limit', type=int,
+            help='Maximum number of executions to retrieve.')
         return parser
 
     def take_action(self, args):

--- a/coriolisclient/cli/transfer_executions.py
+++ b/coriolisclient/cli/transfer_executions.py
@@ -189,17 +189,17 @@ class ListTransferExecution(lister.Lister):
             help='Maximum number of executions to retrieve.')
         parser.add_argument(
             '--sort',
-            help='Comma-separated list of sort keys and directions in the form '
-           'of <key>[:<asc|desc>]. The direction defaults to descending if '
-           'not specified.')
+            help='Comma-separated list of sort keys and directions in the '
+                 'form of <key>[:<asc|desc>]. The direction defaults to '
+                 'descending if not specified.')
         return parser
 
     def take_action(self, args):
-        sort_keys, sort_dirs = cli_utils.parse_sort_args(arg.sort)
+        sort_keys, sort_dirs = cli_utils.parse_sort_args(args.sort)
         obj_list = self.app.client_manager.coriolis.transfer_executions.list(
             args.transfer,
             marker=args.marker,
             limit=args.limit,
-            sort_keys=sort_keys,
-            sort_dirs=sort_dirs)
+            sort_keys=args.sort_keys,
+            sort_dirs=args.sort_dirs)
         return TransferExecutionFormatter().list_objects(obj_list)

--- a/coriolisclient/cli/transfers.py
+++ b/coriolisclient/cli/transfers.py
@@ -334,11 +334,13 @@ class ListTransfer(lister.Lister):
         return parser
 
     def take_action(self, args):
+        sort_keys, sort_dirs = cli_utils.parse_sort_arg(args.sort)
         obj_list = self.app.client_manager.coriolis.transfers.list(
             marker=args.marker,
             limit=args.limit,
-            sort_keys=args.sort_keys,
-            sort_dirs=args.sort_dirs)
+            sort_keys=sort_keys,
+            sort_dirs=sort_dirs,
+        )
         return TransferFormatter().list_objects(obj_list)
 
 

--- a/coriolisclient/cli/transfers.py
+++ b/coriolisclient/cli/transfers.py
@@ -322,10 +322,10 @@ class ListTransfer(lister.Lister):
         parser = super(ListTransfer, self).get_parser(prog_name)
         parser.add_argument(
             '--marker',
-            help='The id of the last retrieved execution.')
+            help='The id of the last retrieved transfer.')
         parser.add_argument(
             '--limit', type=int,
-            help='Maximum number of executions to retrieve.')
+            help='Maximum number of transfers to retrieve.')
         parser.add_argument(
             '--sort',
             help='Comma-separated list of sort keys and directions in the '

--- a/coriolisclient/cli/transfers.py
+++ b/coriolisclient/cli/transfers.py
@@ -320,10 +320,25 @@ class ListTransfer(lister.Lister):
 
     def get_parser(self, prog_name):
         parser = super(ListTransfer, self).get_parser(prog_name)
+        parser.add_argument(
+            '--marker',
+            help='The id of the last retrieved execution.')
+        parser.add_argument(
+            '--limit', type=int,
+            help='Maximum number of executions to retrieve.')
+        parser.add_argument(
+            '--sort',
+            help='Comma-separated list of sort keys and directions in the '
+                 'form of <key>[:<asc|desc>]. The direction defaults to '
+                 'descending if not specified.')
         return parser
 
     def take_action(self, args):
-        obj_list = self.app.client_manager.coriolis.transfers.list()
+        obj_list = self.app.client_manager.coriolis.transfers.list(
+            marker=args.marker,
+            limit=args.limit,
+            sort_keys=args.sort_keys,
+            sort_dirs=args.sort_dirs)
         return TransferFormatter().list_objects(obj_list)
 
 

--- a/coriolisclient/cli/utils.py
+++ b/coriolisclient/cli/utils.py
@@ -20,6 +20,7 @@ import os
 import uuid
 
 from coriolisclient import constants
+from coriolisclient import exceptions
 
 
 def add_storage_mappings_arguments_to_parser(parser):
@@ -264,3 +265,25 @@ def add_minion_pool_args_to_parser(
                  'same OS type and which are compatible with OSMorphing '
                  'the guest OS of each afferent instance. The mappings must '
                  'be of the form "INSTANCE_IDENTIFIER=MINION_POOL_ID".')
+
+
+def parse_sort_arg(sort: str) -> tuple[list, list]:
+    """Parse sort CLI argument.
+
+    :param sort: Comma-separated list of sort keys and directions in the form
+                 of <key>[:<asc|desc>]. The direction defaults to descending if
+                 not specified.
+    :returns: (sort_keys, sort_dirs)
+    """
+    sort_keys = []
+    sort_dirs = []
+    for sort_entry in sort.split(','):
+        sort_key, _sep, sort_dir = sort_entry.partition(':')
+        if not sort_dir:
+            sort_dir = 'desc'
+        elif sort_dir not in ('asc', 'desc'):
+            raise exceptions.CoriolisException(
+                'Unknown sort direction: %s' % sort_dir)
+        sort_keys.append(sort_key)
+        sort_dirs.append(sort_dir)
+    return sort_keys, sort_dirs

--- a/coriolisclient/cli/utils.py
+++ b/coriolisclient/cli/utils.py
@@ -267,7 +267,7 @@ def add_minion_pool_args_to_parser(
                  'be of the form "INSTANCE_IDENTIFIER=MINION_POOL_ID".')
 
 
-def parse_sort_arg(sort: str) -> tuple[list, list]:
+def parse_sort_arg(sort: str | None) -> tuple[list, list]:
     """Parse sort CLI argument.
 
     :param sort: Comma-separated list of sort keys and directions in the form
@@ -277,6 +277,9 @@ def parse_sort_arg(sort: str) -> tuple[list, list]:
     """
     sort_keys = []
     sort_dirs = []
+    if not sort:
+        return sort_keys, sort_dirs
+
     for sort_entry in sort.split(','):
         sort_key, _sep, sort_dir = sort_entry.partition(':')
         if not sort_dir:

--- a/coriolisclient/tests/cli/test_deployments.py
+++ b/coriolisclient/tests/cli/test_deployments.py
@@ -329,12 +329,23 @@ class ListDeploymentTestCase(test_base.CoriolisBaseTestCase):
         parser = self.cli.get_parser('coriolis')
         self.assertIsInstance(parser, argparse.ArgumentParser)
 
-    def test_take_action(self):
+    @mock.patch("coriolisclient.cli.utils.parse_sort_arg")
+    def test_take_action(self, mock_parse_sort_arg):
+        mock_parse_sort_arg.return_value = (
+            mock.sentinel.sort_keys, mock.sentinel.sort_dirs)
+
+        mock_args = mock.MagicMock()
         mock_fun = self.mock_app.client_manager.coriolis.deployments.list
         mock_fun.return_value = [
             v1_deployments.Deployment(mock.MagicMock(), DEPLOYMENT_LIST_DATA)]
 
-        columns, data = self.cli.take_action(mock.ANY)
+        columns, data = self.cli.take_action(mock_args)
 
         self.assertEqual(deployments.DeploymentFormatter().columns, columns)
         self.assertEqual([DEPLOYMENT_LIST_FORMATTED_DATA], list(data))
+        mock_fun.assert_called_once_with(
+            marker=mock_args.marker,
+            limit=mock_args.limit,
+            sort_keys=mock.sentinel.sort_keys,
+            sort_dirs=mock.sentinel.sort_dirs,
+        )

--- a/coriolisclient/tests/cli/test_transfer_executions.py
+++ b/coriolisclient/tests/cli/test_transfer_executions.py
@@ -419,10 +419,15 @@ class ListTransferExecutionTestCase(test_base.CoriolisBaseTestCase):
 
     @mock.patch.object(transfer_executions.TransferExecutionFormatter,
                        'list_objects')
+    @mock.patch("coriolisclient.cli.utils.parse_sort_arg")
     def test_take_action(
         self,
+        mock_parse_sort_arg,
         mock_list_objects
     ):
+        mock_parse_sort_arg.return_value = (
+            mock.sentinel.sort_keys, mock.sentinel.sort_dirs)
+
         args = mock.Mock()
         args.transfer = mock.sentinel.transfer
         mock_transfer_list = mock.Mock()
@@ -435,6 +440,12 @@ class ListTransferExecutionTestCase(test_base.CoriolisBaseTestCase):
             mock_list_objects.return_value,
             result
         )
-        mock_transfer_list.assert_called_once_with(mock.sentinel.transfer)
+        mock_transfer_list.assert_called_once_with(
+            mock.sentinel.transfer,
+            marker=args.marker,
+            limit=args.limit,
+            sort_keys=mock.sentinel.sort_keys,
+            sort_dirs=mock.sentinel.sort_dirs,
+        )
         mock_list_objects.assert_called_once_with(
             mock_transfer_list.return_value)

--- a/coriolisclient/tests/cli/test_transfers.py
+++ b/coriolisclient/tests/cli/test_transfers.py
@@ -470,10 +470,16 @@ class ListTransferTestCase(test_base.CoriolisBaseTestCase):
         mock_get_parser.assert_called_once_with(mock.sentinel.prog_name)
 
     @mock.patch.object(transfers.TransferFormatter, 'list_objects')
-    def test_take_action(self, mock_list_objects):
+    @mock.patch("coriolisclient.cli.utils.parse_sort_arg")
+    def test_take_action(self, mock_parse_sort_arg, mock_list_objects):
+        mock_parse_sort_arg.return_value = (
+            mock.sentinel.sort_keys, mock.sentinel.sort_dirs)
+
         args = mock.Mock()
-        mock_transfer = mock.Mock()
-        self.mock_app.client_manager.coriolis.transfers.list = mock_transfer
+        args.sort = None
+        mock_transfer_list = mock.Mock()
+        self.mock_app.client_manager.coriolis.transfers.list = (
+            mock_transfer_list)
 
         result = self.transfer.take_action(args)
 
@@ -481,7 +487,14 @@ class ListTransferTestCase(test_base.CoriolisBaseTestCase):
             mock_list_objects.return_value,
             result
         )
-        mock_list_objects.assert_called_once_with(mock_transfer.return_value)
+        mock_list_objects.assert_called_once_with(
+            mock_transfer_list.return_value)
+        mock_transfer_list.assert_called_once_with(
+            marker=args.marker,
+            limit=args.limit,
+            sort_keys=mock.sentinel.sort_keys,
+            sort_dirs=mock.sentinel.sort_dirs,
+        )
 
 
 class UpdateTransferTestCase(test_base.CoriolisBaseTestCase):

--- a/coriolisclient/tests/cli/test_utils.py
+++ b/coriolisclient/tests/cli/test_utils.py
@@ -323,3 +323,13 @@ class UtilsTestCase(test_base.CoriolisBaseTestCase):
             [{'instance_id': 'mock_instance_id', 'pool_id': 'mock_pool_id'}],
             args.instance_osmorphing_minion_pool_mappings
         )
+
+    @ddt.data(
+        (None, ([], [])),
+        ("key0:asc,key1:desc,key2",
+            (["key0", "key1", "key2"], ["asc", "desc", "desc"]))
+    )
+    @ddt.unpack
+    def test_parse_sort_arg(self, sort_arg, exp_ret):
+        ret = utils.parse_sort_arg(sort_arg)
+        self.assertEqual(exp_ret, ret)

--- a/coriolisclient/tests/test_base.py
+++ b/coriolisclient/tests/test_base.py
@@ -279,7 +279,7 @@ class BaseManagerTestCase(CoriolisBaseTestCase):
         self.manager = base.BaseManager(mock_client)
 
     def test_list(self):
-        self.manager.client.get(mock.sentinel.url).json.return_value = {
+        self.manager.client.get.return_value.json.return_value = {
             "mock_response_key": {
                 "data": [mock.sentinel.data1, mock.sentinel.data2]}
         }
@@ -294,6 +294,7 @@ class BaseManagerTestCase(CoriolisBaseTestCase):
             values_key="data"
         )
 
+        self.manager.client.get.assert_called_once_with(mock.sentinel.url)
         self.assertEqual(
             [obj_class.return_value] * 2,
             result
@@ -302,6 +303,46 @@ class BaseManagerTestCase(CoriolisBaseTestCase):
             mock.call(self.manager, mock.sentinel.data1, loaded=True),
             mock.call(self.manager, mock.sentinel.data2, loaded=True)
         ])
+
+    def test_list_with_dict_query(self):
+        self.manager.client.get.return_value.json.return_value = {
+            "mock_response_key": {"data": []}
+        }
+        testutils.get_wrapped_function(self.manager._list)(
+            self.manager,
+            url="test-url",
+            response_key="mock_response_key",
+            obj_class=mock.Mock(),
+            json=None,
+            values_key="data",
+            query={
+                "some_filter": "some_value",
+                "some_other_filter": "some_other_value"
+            }
+        )
+        self.manager.client.get.assert_called_once_with(
+            "test-url?some_filter=some_value&"
+            "some_other_filter=some_other_value")
+
+    def test_list_with_tuple_list_query(self):
+        self.manager.client.get.return_value.json.return_value = {
+            "mock_response_key": {"data": []}
+        }
+        testutils.get_wrapped_function(self.manager._list)(
+            self.manager,
+            url="test-url",
+            response_key="mock_response_key",
+            obj_class=mock.Mock(),
+            json=None,
+            values_key="data",
+            query=[
+                ("some_filter", "some_value"),
+                ("some_other_filter", "some_other_value"),
+            ]
+        )
+        self.manager.client.get.assert_called_once_with(
+            "test-url?some_filter=some_value&"
+            "some_other_filter=some_other_value")
 
     def test_list_json(self):
         (self.manager.client.post(mock.sentinel.url, json=True).json.

--- a/coriolisclient/tests/v1/test_deployments.py
+++ b/coriolisclient/tests/v1/test_deployments.py
@@ -75,7 +75,28 @@ class DeploymentManagerTestCase(test_base.CoriolisBaseTestCase):
             result = self.deployments.list(detail=True)
             self.assertEqual(mock_list.return_value, result)
             mock_list.assert_called_once_with(
-                '/deployments/detail', 'deployments')
+                '/deployments/detail', 'deployments', query=[])
+
+    def test_list_with_pagination(self):
+        with mock.patch.object(self.deployments, '_list') as mock_list:
+            result = self.deployments.list(
+                detail=True,
+                marker=mock.sentinel.marker,
+                limit=mock.sentinel.limit,
+                sort_keys=[mock.sentinel.sort_key0, mock.sentinel.sort_key1],
+                sort_dirs=[mock.sentinel.sort_dir0, mock.sentinel.sort_dir1],
+            )
+            exp_query = [
+                ("marker", mock.sentinel.marker),
+                ("limit", mock.sentinel.limit),
+                ("sort_key", mock.sentinel.sort_key0),
+                ("sort_key", mock.sentinel.sort_key1),
+                ("sort_dir", mock.sentinel.sort_dir0),
+                ("sort_dir", mock.sentinel.sort_dir1),
+            ]
+            self.assertEqual(mock_list.return_value, result)
+            mock_list.assert_called_once_with(
+                '/deployments/detail', 'deployments', query=exp_query)
 
     def test_get(self):
         deployment = mock.Mock(uuid=DEPLOYMENT_ID)

--- a/coriolisclient/tests/v1/test_transfer_executions.py
+++ b/coriolisclient/tests/v1/test_transfer_executions.py
@@ -49,7 +49,33 @@ class TransferExecutionManagerTestCase(test_base.CoriolisBaseTestCase):
             result
         )
         mock_list.assert_called_once_with(
-            '/transfers/%s/executions' % mock.sentinel.transfer, "executions")
+            '/transfers/%s/executions' % mock.sentinel.transfer, "executions",
+            query=[])
+
+    @mock.patch.object(transfer_executions.TransferExecutionManager, "_list")
+    def test_list_with_pagination(self, mock_list):
+        result = self.transfer_execution.list(
+            mock.sentinel.transfer,
+            marker=mock.sentinel.marker,
+            limit=mock.sentinel.limit,
+            sort_keys=[mock.sentinel.sort_key0, mock.sentinel.sort_key1],
+            sort_dirs=[mock.sentinel.sort_dir0, mock.sentinel.sort_dir1],
+        )
+        exp_query = [
+            ("marker", mock.sentinel.marker),
+            ("limit", mock.sentinel.limit),
+            ("sort_key", mock.sentinel.sort_key0),
+            ("sort_key", mock.sentinel.sort_key1),
+            ("sort_dir", mock.sentinel.sort_dir0),
+            ("sort_dir", mock.sentinel.sort_dir1),
+        ]
+        self.assertEqual(
+            mock_list.return_value,
+            result
+        )
+        mock_list.assert_called_once_with(
+            '/transfers/%s/executions' % mock.sentinel.transfer, "executions",
+            query=exp_query)
 
     @mock.patch.object(transfer_executions.TransferExecutionManager, "_get")
     def test_get(self, mock_get):

--- a/coriolisclient/tests/v1/test_transfers.py
+++ b/coriolisclient/tests/v1/test_transfers.py
@@ -85,7 +85,30 @@ class TransferManagerTestCase(test_base.CoriolisBaseTestCase):
             mock_list.return_value,
             result
         )
-        mock_list.assert_called_once_with("/transfers", "transfers")
+        mock_list.assert_called_once_with("/transfers", "transfers", query=[])
+
+    @mock.patch.object(transfers.TransferManager, "_list")
+    def test_list_with_pagination(self, mock_list):
+        result = self.transfer.list(
+            detail=False,
+            marker=mock.sentinel.marker,
+            limit=mock.sentinel.limit,
+            sort_keys=[mock.sentinel.sort_key0, mock.sentinel.sort_key1],
+            sort_dirs=[mock.sentinel.sort_dir0, mock.sentinel.sort_dir1],)
+        exp_query = [
+            ("marker", mock.sentinel.marker),
+            ("limit", mock.sentinel.limit),
+            ("sort_key", mock.sentinel.sort_key0),
+            ("sort_key", mock.sentinel.sort_key1),
+            ("sort_dir", mock.sentinel.sort_dir0),
+            ("sort_dir", mock.sentinel.sort_dir1),
+        ]
+        self.assertEqual(
+            mock_list.return_value,
+            result
+        )
+        mock_list.assert_called_once_with(
+            "/transfers", "transfers", query=exp_query)
 
     @mock.patch.object(transfers.TransferManager, "_list")
     def test_list_details(self, mock_list):
@@ -95,7 +118,8 @@ class TransferManagerTestCase(test_base.CoriolisBaseTestCase):
             mock_list.return_value,
             result
         )
-        mock_list.assert_called_once_with("/transfers/detail", "transfers")
+        mock_list.assert_called_once_with(
+            "/transfers/detail", "transfers", query=[])
 
     @mock.patch.object(transfers.TransferManager, "_get")
     def test_get(self, mock_get):

--- a/coriolisclient/v1/deployments.py
+++ b/coriolisclient/v1/deployments.py
@@ -52,11 +52,25 @@ class DeploymentManager(base.BaseManager):
     def __init__(self, api):
         super(DeploymentManager, self).__init__(api)
 
-    def list(self, detail=False):
+    def list(self, detail=False,
+             marker=None, limit=None,
+             sort_keys=None, sort_dirs=None):
+        query = []
+        if marker is not None:
+            query.append(("marker", marker))
+        if limit is not None:
+            query.append(("limit", limit))
+        if sort_keys is not None:
+            query.extend(('sort_key', sort_key)
+                         for sort_key in sort_keys)
+        if sort_dirs is not None:
+            query.extend(('sort_dir', sort_dir)
+                         for sort_dir in sort_dirs)
+
         path = "/deployments"
         if detail:
             path = "%s/detail" % path
-        return self._list(path, 'deployments')
+        return self._list(path, 'deployments', query=query)
 
     def get(self, deployment):
         return self._get(

--- a/coriolisclient/v1/transfer_executions.py
+++ b/coriolisclient/v1/transfer_executions.py
@@ -34,9 +34,16 @@ class TransferExecutionManager(base.BaseManager):
     def __init__(self, api):
         super(TransferExecutionManager, self).__init__(api)
 
-    def list(self, transfer):
+    def list(self, transfer, marker=None, limit=None):
+        query = {}
+        if marker is not None:
+            query['marker'] = marker
+        if limit is not None:
+            query['limit'] = limit
+
         return self._list(
-            '/transfers/%s/executions' % base.getid(transfer), 'executions')
+            '/transfers/%s/executions' % base.getid(transfer), 'executions',
+            query=query)
 
     def get(self, transfer, execution):
         return self._get(

--- a/coriolisclient/v1/transfer_executions.py
+++ b/coriolisclient/v1/transfer_executions.py
@@ -34,12 +34,20 @@ class TransferExecutionManager(base.BaseManager):
     def __init__(self, api):
         super(TransferExecutionManager, self).__init__(api)
 
-    def list(self, transfer, marker=None, limit=None):
-        query = {}
+    def list(self, transfer, marker=None, limit=None,
+             sort_keys=None, sort_dirs=None):
+        # List of key-value tuples.
+        query = []
         if marker is not None:
-            query['marker'] = marker
+            query.append(("marker", marker))
         if limit is not None:
-            query['limit'] = limit
+            query.append(("limit", limit))
+        if sort_keys is not None:
+            query.extend(('sort_key', sort_key)
+                         for sort_key in sort_keys)
+        if sort_dirs is not None:
+            query.extend(('sort_dir', sort_dir)
+                         for sort_dir in sort_dirs)
 
         return self._list(
             '/transfers/%s/executions' % base.getid(transfer), 'executions',

--- a/coriolisclient/v1/transfers.py
+++ b/coriolisclient/v1/transfers.py
@@ -47,11 +47,25 @@ class TransferManager(base.BaseManager):
     def __init__(self, api):
         super(TransferManager, self).__init__(api)
 
-    def list(self, detail=False):
+    def list(self, detail=False, marker=None, limit=None,
+             sort_keys=None, sort_dirs=None):
+        # List of key-value tuples.
+        query = []
+        if marker is not None:
+            query.append(("marker", marker))
+        if limit is not None:
+            query.append(("limit", limit))
+        if sort_keys is not None:
+            query.extend(('sort_key', sort_key)
+                         for sort_key in sort_keys)
+        if sort_dirs is not None:
+            query.extend(('sort_dir', sort_dir)
+                         for sort_dir in sort_dirs)
+
         path = "/transfers"
         if detail:
             path = "%s/detail" % path
-        return self._list(path, 'transfers')
+        return self._list(path, 'transfers', query=query)
 
     def get(self, transfer):
         return self._get('/transfers/%s' % base.getid(transfer), 'transfer')


### PR DESCRIPTION
At the moment, listing endpoint instances is the only Coriolis API that supports pagination. For this reason, Coriolis clients often retrieve much more database records than needed, leading to poor performance.

We're now adding pagination to other Coriolis APIs:
* transfers
* transfer executions
* deployments

New optional parameters:
* ``sort_key`` - sort key, repeatable. `created_at` and `id` are used by default.
* ``sort_dir`` - sort direction, repeatable. `asc` or `desc` (default).
* ``marker`` - the last seen ID, omitted from the results.
* ``limit`` - the maximum number of records to retrieve.

Example:

```
GET http://server:7667/v1/transfers?marker=a7061715-e56c-470c-a6ac-80bb02f1f198&limit=2&sort_key=id&sort_dir=asc
```