### PR TITLE
Allow filtering resources by status

### DIFF
--- a/coriolisclient/cli/deployments.py
+++ b/coriolisclient/cli/deployments.py
@@ -284,14 +284,21 @@ class ListDeployment(lister.Lister):
             help='Comma-separated list of sort keys and directions in the '
                  'form of <key>[:<asc|desc>]. The direction defaults to '
                  'descending if not specified.')
+        parser.add_argument(
+            '--status',
+            help='Search by deployment status.')
         return parser
 
     def take_action(self, args):
+        filters = {}
+        if args.status:
+            filters["status"] = args.status
         sort_keys, sort_dirs = cli_utils.parse_sort_arg(args.sort)
         obj_list = self.app.client_manager.coriolis.deployments.list(
             marker=args.marker,
             limit=args.limit,
             sort_keys=sort_keys,
             sort_dirs=sort_dirs,
+            filters=filters,
         )
         return DeploymentFormatter().list_objects(obj_list)

--- a/coriolisclient/cli/transfer_executions.py
+++ b/coriolisclient/cli/transfer_executions.py
@@ -192,14 +192,22 @@ class ListTransferExecution(lister.Lister):
             help='Comma-separated list of sort keys and directions in the '
                  'form of <key>[:<asc|desc>]. The direction defaults to '
                  'descending if not specified.')
+        parser.add_argument(
+            '--status',
+            help='Search by execution status.')
         return parser
 
     def take_action(self, args):
+        filters = {}
+        if args.status:
+            filters["status"] = args.status
         sort_keys, sort_dirs = cli_utils.parse_sort_arg(args.sort)
         obj_list = self.app.client_manager.coriolis.transfer_executions.list(
             args.transfer,
             marker=args.marker,
             limit=args.limit,
             sort_keys=sort_keys,
-            sort_dirs=sort_dirs)
+            sort_dirs=sort_dirs,
+            filters=filters,
+        )
         return TransferExecutionFormatter().list_objects(obj_list)

--- a/coriolisclient/cli/transfers.py
+++ b/coriolisclient/cli/transfers.py
@@ -331,15 +331,22 @@ class ListTransfer(lister.Lister):
             help='Comma-separated list of sort keys and directions in the '
                  'form of <key>[:<asc|desc>]. The direction defaults to '
                  'descending if not specified.')
+        parser.add_argument(
+            '--status',
+            help='Search by transfer status.')
         return parser
 
     def take_action(self, args):
+        filters = {}
+        if args.status:
+            filters["status"] = args.status
         sort_keys, sort_dirs = cli_utils.parse_sort_arg(args.sort)
         obj_list = self.app.client_manager.coriolis.transfers.list(
             marker=args.marker,
             limit=args.limit,
             sort_keys=sort_keys,
             sort_dirs=sort_dirs,
+            filters=filters,
         )
         return TransferFormatter().list_objects(obj_list)
 

--- a/coriolisclient/tests/cli/test_deployments.py
+++ b/coriolisclient/tests/cli/test_deployments.py
@@ -348,4 +348,5 @@ class ListDeploymentTestCase(test_base.CoriolisBaseTestCase):
             limit=mock_args.limit,
             sort_keys=mock.sentinel.sort_keys,
             sort_dirs=mock.sentinel.sort_dirs,
+            filters={'status': mock_args.status},
         )

--- a/coriolisclient/tests/cli/test_transfer_executions.py
+++ b/coriolisclient/tests/cli/test_transfer_executions.py
@@ -446,6 +446,7 @@ class ListTransferExecutionTestCase(test_base.CoriolisBaseTestCase):
             limit=args.limit,
             sort_keys=mock.sentinel.sort_keys,
             sort_dirs=mock.sentinel.sort_dirs,
+            filters={'status': args.status},
         )
         mock_list_objects.assert_called_once_with(
             mock_transfer_list.return_value)

--- a/coriolisclient/tests/cli/test_transfers.py
+++ b/coriolisclient/tests/cli/test_transfers.py
@@ -494,6 +494,7 @@ class ListTransferTestCase(test_base.CoriolisBaseTestCase):
             limit=args.limit,
             sort_keys=mock.sentinel.sort_keys,
             sort_dirs=mock.sentinel.sort_dirs,
+            filters={'status': args.status},
         )
 
 

--- a/coriolisclient/tests/v1/test_deployments.py
+++ b/coriolisclient/tests/v1/test_deployments.py
@@ -85,6 +85,7 @@ class DeploymentManagerTestCase(test_base.CoriolisBaseTestCase):
                 limit=mock.sentinel.limit,
                 sort_keys=[mock.sentinel.sort_key0, mock.sentinel.sort_key1],
                 sort_dirs=[mock.sentinel.sort_dir0, mock.sentinel.sort_dir1],
+                filters={"status": mock.sentinel.status},
             )
             exp_query = [
                 ("marker", mock.sentinel.marker),
@@ -93,6 +94,7 @@ class DeploymentManagerTestCase(test_base.CoriolisBaseTestCase):
                 ("sort_key", mock.sentinel.sort_key1),
                 ("sort_dir", mock.sentinel.sort_dir0),
                 ("sort_dir", mock.sentinel.sort_dir1),
+                ("status", mock.sentinel.status),
             ]
             self.assertEqual(mock_list.return_value, result)
             mock_list.assert_called_once_with(

--- a/coriolisclient/tests/v1/test_transfer_executions.py
+++ b/coriolisclient/tests/v1/test_transfer_executions.py
@@ -60,6 +60,7 @@ class TransferExecutionManagerTestCase(test_base.CoriolisBaseTestCase):
             limit=mock.sentinel.limit,
             sort_keys=[mock.sentinel.sort_key0, mock.sentinel.sort_key1],
             sort_dirs=[mock.sentinel.sort_dir0, mock.sentinel.sort_dir1],
+            filters={"status": mock.sentinel.status},
         )
         exp_query = [
             ("marker", mock.sentinel.marker),
@@ -68,6 +69,7 @@ class TransferExecutionManagerTestCase(test_base.CoriolisBaseTestCase):
             ("sort_key", mock.sentinel.sort_key1),
             ("sort_dir", mock.sentinel.sort_dir0),
             ("sort_dir", mock.sentinel.sort_dir1),
+            ("status", mock.sentinel.status),
         ]
         self.assertEqual(
             mock_list.return_value,

--- a/coriolisclient/tests/v1/test_transfers.py
+++ b/coriolisclient/tests/v1/test_transfers.py
@@ -94,7 +94,9 @@ class TransferManagerTestCase(test_base.CoriolisBaseTestCase):
             marker=mock.sentinel.marker,
             limit=mock.sentinel.limit,
             sort_keys=[mock.sentinel.sort_key0, mock.sentinel.sort_key1],
-            sort_dirs=[mock.sentinel.sort_dir0, mock.sentinel.sort_dir1],)
+            sort_dirs=[mock.sentinel.sort_dir0, mock.sentinel.sort_dir1],
+            filters={"status": mock.sentinel.status},
+        )
         exp_query = [
             ("marker", mock.sentinel.marker),
             ("limit", mock.sentinel.limit),
@@ -102,6 +104,7 @@ class TransferManagerTestCase(test_base.CoriolisBaseTestCase):
             ("sort_key", mock.sentinel.sort_key1),
             ("sort_dir", mock.sentinel.sort_dir0),
             ("sort_dir", mock.sentinel.sort_dir1),
+            ("status", mock.sentinel.status)
         ]
         self.assertEqual(
             mock_list.return_value,

--- a/coriolisclient/v1/deployments.py
+++ b/coriolisclient/v1/deployments.py
@@ -54,7 +54,7 @@ class DeploymentManager(base.BaseManager):
 
     def list(self, detail=False,
              marker=None, limit=None,
-             sort_keys=None, sort_dirs=None):
+             sort_keys=None, sort_dirs=None, filters=None):
         query = []
         if marker is not None:
             query.append(("marker", marker))
@@ -66,6 +66,8 @@ class DeploymentManager(base.BaseManager):
         if sort_dirs is not None:
             query.extend(('sort_dir', sort_dir)
                          for sort_dir in sort_dirs)
+        if filters:
+            query.extend((key, value) for key, value in filters.items())
 
         path = "/deployments"
         if detail:

--- a/coriolisclient/v1/transfer_executions.py
+++ b/coriolisclient/v1/transfer_executions.py
@@ -35,7 +35,7 @@ class TransferExecutionManager(base.BaseManager):
         super(TransferExecutionManager, self).__init__(api)
 
     def list(self, transfer, marker=None, limit=None,
-             sort_keys=None, sort_dirs=None):
+             sort_keys=None, sort_dirs=None, filters=None):
         # List of key-value tuples.
         query = []
         if marker is not None:
@@ -48,6 +48,8 @@ class TransferExecutionManager(base.BaseManager):
         if sort_dirs is not None:
             query.extend(('sort_dir', sort_dir)
                          for sort_dir in sort_dirs)
+        if filters:
+            query.extend((key, value) for key, value in filters.items())
 
         return self._list(
             '/transfers/%s/executions' % base.getid(transfer), 'executions',

--- a/coriolisclient/v1/transfers.py
+++ b/coriolisclient/v1/transfers.py
@@ -48,7 +48,7 @@ class TransferManager(base.BaseManager):
         super(TransferManager, self).__init__(api)
 
     def list(self, detail=False, marker=None, limit=None,
-             sort_keys=None, sort_dirs=None):
+             sort_keys=None, sort_dirs=None, filters=None):
         # List of key-value tuples.
         query = []
         if marker is not None:
@@ -61,6 +61,8 @@ class TransferManager(base.BaseManager):
         if sort_dirs is not None:
             query.extend(('sort_dir', sort_dir)
                          for sort_dir in sort_dirs)
+        if filters:
+            query.extend((key, value) for key, value in filters.items())
 
         path = "/transfers"
         if detail:


### PR DESCRIPTION
We're adding a "status" search option that can be specified when listing the following resources:

* deployments
    * status -> last_execution_status db field
* transfers
* transfer executions

The filtering will be performed on the service side.